### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,6 @@ python3 --version
 
 This should return something like `Python 3.7.3`.
 
-### Install virtualenv
-
-We use virtualenv to ensure that every developer is using the same dependency versions.
-
-```
-pip3 install --user virtualenv
-```
-
 ### Install Postgres
 
 Install and run a PostgreSQL on your computer.
@@ -48,7 +40,9 @@ cp .env.template .env
 
 `.env` is included in the `.gitignore` for this repo and won't be included when you commit your changes.
 
-### Start the virtualenv (aka venv)
+### Start the virtual environment (aka venv)
+
+We use [venv](https://docs.python.org/3/library/venv.html) to ensure that every developer is using the same dependency versions.
 
 ```
 python3 -m venv env


### PR DESCRIPTION
I realized that I can test on repl.it instead of testing with my computer!

It seems that since [venv](https://docs.python.org/3/library/venv.html) and [virtualenv](https://virtualenv.pypa.io/en/latest/) are two different things (which is v confusing), we don't need to install virtualenv.

We don't need to install venv either since it's a part of the Python Standard Library!