### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+# https://circleci.com/developer/orbs/orb/circleci/python#quick-start
+version: 2.1
+
+orbs:
+  python: circleci/python@1.2.1
+
+workflows:
+  main:
+    jobs:
+      - python/test


### PR DESCRIPTION
Fix #3

This PR is just #18 with a cleaner git history

Good news: I got CircleCI to run tests and GitHub shows the green check mark now (Pretty easy! After everything Maureen did, all I had to do was add `.circleci/config.yml`)

Bad news: I just copied the contents of `.env` to CircleCI to get it to work. We'll have to fix that in #19 

https://app.circleci.com/settings/project/github/RagtagOpen/freefrom-map-backend/environment-variables