### PR TITLE
GET /criteria and GET /criteria/id endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,46 @@ Run tests with the following command:
 ```
 python3 -m unittest
 ```
+
+## API Reference
+The following section describes the FreeFrom map backend API. All responses will be formatted as JSON, and all
+request bodies should be provided as JSON.
+
+### Categories
+A category represents a group of criteria in the map scorecard. A category has the following fields:
+
+|  Name  |   Type  |    Notes    |
+|--------|---------|-------------|
+| id     | Integer | Primary key |
+| title  | String  |             |
+| active | Boolean |             |
+
+#### GET /categories
+
+This endpoint returns a list of all existing categories. It will return an empty array if no categories exist.
+
+#### GET /categories/<id>
+
+This endpoint returns one category corresponding to the id provided in the request. If no category with that
+id exists, it will return a 404 response code.
+
+### Criteria
+
+A criterion represents one measure in the state scorecard to determine whether a state has strong survivor wealth policies.
+
+|         Name        |   Type   |    Notes    |
+|---------------------|----------|-------------|
+| id                  | Integer  | Primary key |
+| category_id         | Integer  | Foreign key |
+| title               | String   |             |
+| recommendation_text | String   |             |
+| active              | Boolean  |             |
+
+### GET /criteria
+
+This endpoint returns a list of all existing criteria. It will return an empty array if no criteria exist.
+
+### GET /criteria/<id>
+
+This endpoint returns one criterion corresponding to the id provided in the request. If no criterion with that
+id exists, it will return a 404 response code.

--- a/app.py
+++ b/app.py
@@ -33,5 +33,25 @@ def get_category(id_):
 	except Exception as e:
 		return(str(e))
 
+@app.route("/criteria")
+def get_criteria():
+	try:
+		criteria=Criterion.query.all()
+		return  jsonify([criterion.serialize() for criterion in criteria])
+	except Exception as e:
+		return(str(e))
+
+@app.route("/criteria/<id_>")
+def get_criterion(id_):
+	try:
+		criterion=Criterion.query.filter_by(id=id_).first()
+
+		if criterion is None:
+			return jsonify(error=404, text="Criterion does not exist"), 404
+
+		return  jsonify(criterion.serialize())
+	except Exception as e:
+		return(str(e))
+
 if __name__ == '__main__':
 		app.run()

--- a/tests/api/test_criteria.py
+++ b/tests/api/test_criteria.py
@@ -1,0 +1,95 @@
+import unittest
+import json
+
+from app import app, db
+from models import Category, Criterion
+from tests.test_utils import clearDatabase
+
+class CriteriaTestCase(unittest.TestCase):
+  def setUp(self):
+    self.client = app.test_client()
+
+    self.category=Category(
+      title="Definition of Domestic Violence",
+      active=True,
+    )
+
+    db.session.add(self.category)
+    db.session.commit()
+
+  def tearDown(self):
+    clearDatabase(db)
+
+  def test_get_criteria(self):
+    criterion1=Criterion(
+      category_id=self.category.id,
+      title="Includes economic abuse framework",
+      recommendation_text="The state's definition of domestic violence should include a framework of economic abuse",
+      active=True
+    )
+
+    criterion2=Criterion(
+      category_id=self.category.id,
+      title="Uses coercive control framework",
+      recommendation_text="The state's definition of domestic violence should use a framework of coercive control",
+      active=True
+    )
+
+    db.session.add_all([criterion1, criterion2])
+    db.session.commit()
+
+    response = self.client.get("/criteria")
+    self.assertEqual(response.status_code, 200)
+    json_response = json.loads(response.data.decode("utf-8"))
+
+    self.assertEqual(len(json_response), 2)
+    self.assertEqual(json_response[0], {
+      "id": criterion1.id,
+      "category_id": criterion1.category_id,
+      "title": "Includes economic abuse framework",
+      "recommendation_text": "The state's definition of domestic violence should include a framework of economic abuse",
+      "active": True
+    })
+    self.assertEqual(json_response[1], {
+      "id": criterion2.id,
+      "category_id": criterion2.category_id,
+      "title": "Uses coercive control framework",
+      "recommendation_text": "The state's definition of domestic violence should use a framework of coercive control",
+      "active": True
+    })
+
+  def test_get_criteria_empty(self):
+    response = self.client.get("/criteria")
+    self.assertEqual(response.status_code, 200)
+    json_response = json.loads(response.data.decode("utf-8"))
+
+    self.assertEqual(json_response, [])
+
+  def test_get_criterion(self):
+    criterion=Criterion(
+      category_id=self.category.id,
+      title="Includes economic abuse framework",
+      recommendation_text="The state's definition of domestic violence should include a framework of economic abuse",
+      active=True
+    )
+    db.session.add(criterion)
+    db.session.commit()
+
+    response = self.client.get("/criteria/%i" % criterion.id)
+    self.assertEqual(response.status_code, 200)
+    json_response = json.loads(response.data.decode("utf-8"))
+
+    self.assertEqual(json_response, {
+      "id": criterion.id,
+      "category_id": criterion.category_id,
+      "title": "Includes economic abuse framework",
+      "recommendation_text": "The state's definition of domestic violence should include a framework of economic abuse",
+      "active": True
+    })
+
+  def test_get_category_doesnt_exist(self):
+    response = self.client.get("/criteria/1")
+    self.assertEqual(response.status_code, 404)
+    json_response = json.loads(response.data.decode("utf-8"))
+
+    self.assertEqual(json_response["text"], "Criterion does not exist")

--- a/tests/models/test_criterion.py
+++ b/tests/models/test_criterion.py
@@ -9,14 +9,13 @@ from tests.test_utils import clearDatabase
 class CriterionTestCase(unittest.TestCase):
   def setUp(self):
     self.client = app.test_client()
-    self.db = db
 
     self.category=Category(
         title="Definition of Domestic Violence",
         active=True,
     )
-    self.db.session.add(self.category)
-    self.db.session.commit()
+    db.session.add(self.category)
+    db.session.commit()
 
     self.criterion=Criterion(
       category_id=self.category.id,
@@ -25,11 +24,11 @@ class CriterionTestCase(unittest.TestCase):
       active=True
     )
 
-    self.db.session.add(self.criterion)
-    self.db.session.commit()
+    db.session.add(self.criterion)
+    db.session.commit()
 
   def tearDown(self):
-    clearDatabase(self.db)
+    clearDatabase(db)
 
   def test_init(self):
     self.assertEqual(self.criterion.category_id, self.category.id)


### PR DESCRIPTION
Closes #29.

Introduces two new endpoints: `GET /criteria` and `GET /criteria/id`.