### PR TITLE
Adding docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 migrations/__pycache__/
 migrations/versions/__pycache__/
 .idea
+migrations
+**/__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ __pycache__/
 migrations/__pycache__/
 migrations/versions/__pycache__/
 .idea
-migrations
-**/__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ env/
 __pycache__/
 migrations/__pycache__/
 migrations/versions/__pycache__/
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,5 @@ RUN pip install -r requirements.txt
 
 RUN chmod +x /app/app-entrypoint.sh
 
-CMD python manage.py db migrate && python manage.py db upgrade
-
 ENTRYPOINT ["/app/app-entrypoint.sh"]
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.7-alpine
+
+WORKDIR /app
+ADD . /app
+
+RUN apk update && apk add linux-headers postgresql-dev gcc python3-dev musl-dev
+
+RUN python3 -m venv env
+RUN source env/bin/activate
+RUN pip install -r requirements.txt
+
+RUN chmod +x /app/app-entrypoint.sh
+
+ENTRYPOINT ["/app/app-entrypoint.sh"]
+EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ ADD . /app
 
 RUN apk update && apk add linux-headers postgresql-dev gcc python3-dev musl-dev
 
-RUN python3 -m venv env
-RUN source env/bin/activate
 RUN pip install -r requirements.txt
 
 RUN chmod +x /app/app-entrypoint.sh
+
+CMD python manage.py db migrate && python manage.py db upgrade
 
 ENTRYPOINT ["/app/app-entrypoint.sh"]
 EXPOSE 5000

--- a/README.md
+++ b/README.md
@@ -6,9 +6,27 @@ Welcome to the FreeFrom Map project backend! This page is under construction so 
 
 ## Local Development Setup
 
-This is a Python Flask app. Follow these steps to run it locally:
+This is a Python Flask app. 
 
-### Install Python
+#### Set up environment variables
+
+Use the provided template to set up a `.env` file with some environment variables you'll need:
+
+```
+cp .env.template .env
+```
+
+`.env` is included in the `.gitignore` for this repo and won't be included when you commit your changes.
+
+#### Setup Instructions
+This app can be set up either locally or within docker.
+
+[Follow these steps to setup and run it locally](#local-setup)
+
+[Follow these steps to setup and run it in docker](#docker-setup)
+
+### Local Setup
+#### Install Python
 
 If you don't already have it installed, install Python 3. You can check that you have it installed using this command:
 
@@ -18,11 +36,11 @@ python3 --version
 
 This should return something like `Python 3.7.3`.
 
-### Install Postgres
+#### Install Postgres
 
 Install and run a PostgreSQL on your computer.
 
-### Set up database roles
+#### Set up database roles
 
 1. Start a Postgres client session: `psql`
 2. Create a new user: `create user "freefrom_map_user";`
@@ -56,13 +74,13 @@ Now, when you run `which python`, you should get something like: `/path/to/your/
 
 You only have to run `python3 -m venv env` once, but you should run `source env/bin/activate` every time you work on this repository.
 
-### Install the requirements
+#### Install the requirements
 
 ```
 pip3 install -r requirements.txt
 ```
 
-### Migrate the database
+#### Migrate the database
 
 ```
 python3 manage.py db migrate
@@ -71,7 +89,7 @@ python3 manage.py db upgrade
 
 If you receive a "Target database is not up to date." error, try `python3 manage.py db stamp head`
 
-## Running the application
+#### Running the application
 
 Run the application with the following command:
 
@@ -81,12 +99,31 @@ python3 manage.py runserver
 
 Then, in your browser, navigate to `localhost:5000/`. You should see the message "Hello world!" on your screen.
 
+### Docker Setup
+1. Download latest docker
+    1. Make sure `docker --version` returns a version
+1. Run `docker-compose up` to build the images.
+
+Then, in your browser, you can navigate to `localhost:5001/categories` and it will return an empty array. 
+
+### Docker Tips
+If you need to shell into a container, either the app or db, you can run: `docker exec -it freefrom_map_app /bin/sh`
+and you will enter into a shell. This is handy if you prefer `psql` over a Database IDE, or need to hop on the containers
+to check something.
+
 ## Running tests
 
 Run tests with the following command:
 
 ```
 python3 -m unittest
+```
+
+
+If in docker, you can run:
+
+```
+docker exec -it freefrom_map_app python -m unittest
 ```
 
 ## Linting

--- a/README.md
+++ b/README.md
@@ -100,11 +100,19 @@ python3 manage.py runserver
 Then, in your browser, navigate to `localhost:5000/`. You should see the message "Hello world!" on your screen.
 
 ### Docker Setup
-1. Download latest docker
-    1. Make sure `docker --version` returns a version
-1. Run `docker-compose up` to build the images.
+1. Set up your local .env with the following `DATABASE_URL="postgresql://freefrom_map_user:password@db/freefrom_map_dev"`
+1. Install docker (verify with `docker --version`)
+1. Run `docker-compose up` in the directory
+1. Pull up http://localhost:5001/categories to view an empty array
+Optional you can insert a record into the endpoint by connecting to the db and inserting a new record into the categories
+   table. To ssh and connect to psql, you'll run:
 
-Then, in your browser, you can navigate to `localhost:5001/categories` and it will return an empty array. 
+```shell
+docker exec -it freefrom_map_db /bin/sh
+psql -U freefrom_map_user -d freefrom_map_dev
+```
+
+Insert new record into categories table, pull it up again via the fetching the endpoint again.
 
 ### Docker Tips
 If you need to shell into a container, either the app or db, you can run: `docker exec -it freefrom_map_app /bin/sh`

--- a/app-entrypoint.sh
+++ b/app-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Migrate DB
+python manage.py db stamp head
+python manage.py db migrate
+python manage.py db upgrade
+
+source env/bin/activate
+
+python3 manage.py runserver --host 0.0.0.0

--- a/app-entrypoint.sh
+++ b/app-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-python manage.py db stamp head
 python manage.py db migrate
 python manage.py db upgrade
 

--- a/app-entrypoint.sh
+++ b/app-entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
-# Migrate DB
 python manage.py db stamp head
 python manage.py db migrate
 python manage.py db upgrade
 
-source env/bin/activate
-
-python3 manage.py runserver --host 0.0.0.0
+python manage.py runserver --host 0.0.0.0

--- a/app-entrypoint.sh
+++ b/app-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+python manage.py db stamp head
 python manage.py db migrate
 python manage.py db upgrade
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.7"
+services:
+  app:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    user: root
+    container_name: freefrom_map_app
+    depends_on:
+      - db
+    ports:
+      - "5001:5000"
+    working_dir: /app
+    volumes:
+      - ./:/app
+    networks:
+      - default
+    restart: always
+
+  db:
+    image: postgres:latest
+    container_name: freefrom_map_db
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_DB: freefrom_map_dev
+      POSTGRES_USER: freefrom_map_user
+      POSTGRES_PASSWORD: password
+    networks:
+      - default
+    restart: always
+
+volumes:
+  db-data:
+
+networks:
+  default:
+    driver: bridge

--- a/migrations/versions/d05d8a998a58_.py
+++ b/migrations/versions/d05d8a998a58_.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd05d8a998a58'
-down_revision = 'd939c467b2ef'
+down_revision = '5460b36b985f'
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/d05d8a998a58_.py
+++ b/migrations/versions/d05d8a998a58_.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd05d8a998a58'
-down_revision = '5460b36b985f'
+down_revision = 'd939c467b2ef'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Adds docker integration for back end.

To spin up, you can follow ReadMe directions or below:

1. Set up your local `.env` with the following `DATABASE_URL="postgresql://freefrom_map_user:password@db/freefrom_map_dev"`
1. Install docker (verify with `docker --version`
1. Run `docker-compose up` in the directory
1. Pull up `http://localhost:5001/categories` to view an empty array

Optional you can insert a record into the endpoint by connecting to the db and inserting a new record into the categories table. To ssh and connect to psql, you'll run:

1. `docker exec -it freefrom_map_db /bin/sh`
1. `psql -U freefrom_map_user -d freefrom_map_dev`
1. Insert new record into `categories` table, pull it up again via the fetching the endpoint again.

This also removes the `__pycache__` folders from everywhere as I don't think these are needed (and were modified after I ran them) - BUT please correct me if I'm wrong!