### PR TITLE
Add authenticated endpoint with tests

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,6 @@
 export APP_SETTINGS="config.DevelopmentConfig"
 export DATABASE_URL="postgresql://localhost/freefrom_map_dev"
+
+# Ask for this information in #proj-freefrom-map-dev in Slack
+export AUTH0_CLIENT_ID=""
+export AUTH0_CLIENT_SECRET=""

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ cp .env.template .env
 
 `.env` is included in the `.gitignore` for this repo and won't be included when you commit your changes.
 
+While .env.template contains some non-sensitive environment variables, there are a few that you'll
+need to get from the team. Ask in the #proj-freefrom-map-dev channel for these variables.
+
 ### Start the virtual environment (aka venv)
 
 We use [venv](https://docs.python.org/3/library/venv.html) to ensure that every developer is using the same dependency versions.

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import os
 from flask import Flask, request, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from dotenv import load_dotenv
+from flask_cors import cross_origin
 
 app = Flask(__name__)
 
@@ -12,6 +13,13 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 
 from models import Category, Criterion, Link, Score
+from auth import AuthError, requires_auth, requires_scope
+
+@app.errorhandler(AuthError)
+def handle_auth_error(ex):
+	response = jsonify(ex.error)
+	response.status_code = ex.status_code
+	return response
 
 @app.route("/categories")
 def get_categories():
@@ -72,6 +80,34 @@ def get_link(id_):
 		return  jsonify(link.serialize())
 	except Exception as e:
 		return(str(e))
+
+# This doesn't need authentication
+@app.route("/api/public")
+@cross_origin(headers=["Content-Type", "Authorization"])
+def public():
+    response = "Hello from a public endpoint! You don't need to be authenticated to see this."
+    return jsonify(message=response)
+
+# This needs authentication
+@app.route("/api/private")
+@cross_origin(headers=["Content-Type", "Authorization"])
+@requires_auth
+def private():
+    response = "Hello from a private endpoint! You need to be authenticated to see this."
+    return jsonify(message=response)
+
+# This needs authorization
+@app.route("/api/private-scoped")
+@cross_origin(headers=["Content-Type", "Authorization"])
+@requires_auth
+def private_scoped():
+    if requires_scope("read:messages"):
+        response = "Hello from a private endpoint! You need to be authenticated and have a scope of read:messages to see this."
+        return jsonify(message=response)
+    raise AuthError({
+        "code": "Unauthorized",
+        "description": "You don't have access to this resource"
+    }, 403)
 
 if __name__ == '__main__':
 		app.run()

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 
 from models import Category, Criterion, Link, Score
-from auth import AuthError, requires_auth, requires_scope
+from auth import AuthError, requires_auth
 
 @app.errorhandler(AuthError)
 def handle_auth_error(ex):
@@ -95,19 +95,6 @@ def public():
 def private():
     response = "Hello from a private endpoint! You need to be authenticated to see this."
     return jsonify(message=response)
-
-# This needs authorization
-@app.route("/api/private-scoped")
-@cross_origin(headers=["Content-Type", "Authorization"])
-@requires_auth
-def private_scoped():
-    if requires_scope("read:messages"):
-        response = "Hello from a private endpoint! You need to be authenticated and have a scope of read:messages to see this."
-        return jsonify(message=response)
-    raise AuthError({
-        "code": "Unauthorized",
-        "description": "You don't have access to this resource"
-    }, 403)
 
 if __name__ == '__main__':
 		app.run()

--- a/auth.py
+++ b/auth.py
@@ -82,18 +82,3 @@ def requires_auth(f):
         raise AuthError({"code": "invalid_header",
                          "description": "Unable to find appropriate key"}, 401)
     return decorated
-
-
-def requires_scope(required_scope):
-    """Determines if the required scope is present in the Access Token
-    Args:
-        required_scope (str): The scope required to access the resource
-    """
-    token = get_token_auth_header()
-    unverified_claims = jwt.get_unverified_claims(token)
-    if unverified_claims.get("scope"):
-        token_scopes = unverified_claims["scope"].split()
-        for token_scope in token_scopes:
-            if token_scope == required_scope:
-                return True
-    return False

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,99 @@
+# https://auth0.com/docs/quickstart/backend/python/#validate-access-tokens
+
+import json
+from six.moves.urllib.request import urlopen
+from functools import wraps
+from flask import request, jsonify, _request_ctx_stack
+from jose import jwt
+
+AUTH0_DOMAIN = 'dev-yhcdtf5o.us.auth0.com'
+API_AUDIENCE = 'freefrom-map-backend'
+ALGORITHMS = ["RS256"]
+
+
+class AuthError(Exception):
+    def __init__(self, error, status_code):
+        self.error = error
+        self.status_code = status_code
+
+
+def get_token_auth_header():
+    """Obtains the Access Token from the Authorization Header"""
+    auth = request.headers.get("Authorization", None)
+    if not auth:
+        raise AuthError({"code": "authorization_header_missing",
+                         "description": "Authorization header is expected"}, 401)
+
+    parts = auth.split()
+
+    if parts[0].lower() != "bearer":
+        raise AuthError({"code": "invalid_header",
+                         "description": "Authorization header must start with Bearer"}, 401)
+    elif len(parts) == 1:
+        raise AuthError({"code": "invalid_header",
+                         "description": "Token not found"}, 401)
+    elif len(parts) > 2:
+        raise AuthError({"code": "invalid_header",
+                         "description": "Authorization header must be Bearer token"}, 401)
+
+    token = parts[1]
+    return token
+
+
+def requires_auth(f):
+    """Determines if the Access Token is valid"""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = get_token_auth_header()
+        jsonurl = urlopen("https://"+AUTH0_DOMAIN+"/.well-known/jwks.json")
+        jwks = json.loads(jsonurl.read())
+        unverified_header = jwt.get_unverified_header(token)
+        rsa_key = {}
+        for key in jwks["keys"]:
+            if key["kid"] == unverified_header["kid"]:
+                rsa_key = {
+                    "kty": key["kty"],
+                    "kid": key["kid"],
+                    "use": key["use"],
+                    "n": key["n"],
+                    "e": key["e"]
+                }
+        if rsa_key:
+            try:
+                payload = jwt.decode(
+                    token,
+                    rsa_key,
+                    algorithms=ALGORITHMS,
+                    audience=API_AUDIENCE,
+                    issuer="https://"+AUTH0_DOMAIN+"/"
+                )
+            except jwt.ExpiredSignatureError:
+                raise AuthError({"code": "token_expired",
+                                 "description": "token is expired"}, 401)
+            except jwt.JWTClaimsError:
+                raise AuthError({"code": "invalid_claims",
+                                 "description": "incorrect claims, please check the audience and issuer"}, 401)
+            except Exception:
+                raise AuthError({"code": "invalid_header",
+                                 "description": "Unable to parse authentication token."}, 401)
+
+            _request_ctx_stack.top.current_user = payload
+            return f(*args, **kwargs)
+        raise AuthError({"code": "invalid_header",
+                         "description": "Unable to find appropriate key"}, 401)
+    return decorated
+
+
+def requires_scope(required_scope):
+    """Determines if the required scope is present in the Access Token
+    Args:
+        required_scope (str): The scope required to access the resource
+    """
+    token = get_token_auth_header()
+    unverified_claims = jwt.get_unverified_claims(token)
+    if unverified_claims.get("scope"):
+        token_scopes = unverified_claims["scope"].split()
+        for token_scope in token_scopes:
+            if token_scope == required_scope:
+                return True
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ python-dateutil==2.8.1
 python-dotenv==0.15.0
 python-editor==1.0.4
 python-jose==3.2.0
+requests==2.25.0
 rsa==4.6
 six==1.15.0
 SQLAlchemy==1.3.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,10 @@ alembic==1.4.3
 appdirs==1.4.4
 click==7.1.2
 distlib==0.3.1
+ecdsa==0.14.1
 filelock==3.0.12
 Flask==1.1.2
+Flask-Cors==3.0.9
 Flask-Migrate==2.5.3
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.4.4
@@ -15,11 +17,14 @@ MarkupSafe==1.1.1
 mtools==1.6.3
 psutil==5.7.0
 psycopg2-binary==2.8.6
+pyasn1==0.4.8
 pymongo==3.10.1
 python-dateutil==2.8.1
-python-dotenv==0.14.0
+python-dotenv==0.15.0
 python-editor==1.0.4
-six==1.12.0
+python-jose==3.2.0
+rsa==4.6
+six==1.15.0
 SQLAlchemy==1.3.20
 virtualenv==20.1.0
 Werkzeug==1.0.1

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,34 @@
+import unittest
+import json
+import requests
+import os
+
+from app import app, db
+from auth import AUTH0_DOMAIN, API_AUDIENCE
+
+class TestAuth(unittest.TestCase):
+  def setUp(self):
+    self.client = app.test_client()
+
+  def test_private_endpoint_no_auth(self):
+    response = self.client.get("/api/private")
+    self.assertEqual(response.status_code, 401)
+    json_response = json.loads(response.data.decode("utf-8"))
+
+    self.assertEqual(json_response["description"], "Authorization header is expected")
+  
+  def test_private_endpoint_auth(self):
+    data = {
+      "client_id": os.environ.get('AUTH0_CLIENT_ID'),
+      "client_secret": os.environ.get('AUTH0_CLIENT_SECRET'),
+      "audience": API_AUDIENCE,
+      "grant_type":"client_credentials"
+    }
+
+    jwt_response = requests.post(f'https://{AUTH0_DOMAIN}/oauth/token', data=data)
+    jwt = json.loads(jwt_response.text)['access_token']
+    
+    headers = {'Authorization': f'Bearer {jwt}'}
+
+    response = self.client.get("/api/private", headers=headers)
+    self.assertEqual(response.status_code, 200)

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -17,6 +17,8 @@ class TestAuth(unittest.TestCase):
 
     self.assertEqual(json_response["description"], "Authorization header is expected")
   
+  @unittest.skipIf(not os.environ.get("AUTH0_CLIENT_ID") or not os.environ.get("AUTH0_CLIENT_SECRET"),
+                     "Cannot run test without AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET environment variables")
   def test_private_endpoint_auth(self):
     data = {
       "client_id": os.environ.get('AUTH0_CLIENT_ID'),


### PR DESCRIPTION
This PR builds off @DanielKim1's work in #47 

Closes #15

The only change is that this PR adds two tests demonstrating that auth works, along with some new environment variables and info in the README.