### PR TITLE
Mock authentication for non-auth API tests

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -39,45 +39,48 @@ def get_token_auth_header():
     token = parts[1]
     return token
 
+def is_token_valid():
+    """Determines if the Access Token is valid"""
+    token = get_token_auth_header()
+    jsonurl = urlopen("https://"+AUTH0_DOMAIN+"/.well-known/jwks.json")
+    jwks = json.loads(jsonurl.read())
+    unverified_header = jwt.get_unverified_header(token)
+    rsa_key = {}
+    for key in jwks["keys"]:
+        if key["kid"] == unverified_header["kid"]:
+            rsa_key = {
+                "kty": key["kty"],
+                "kid": key["kid"],
+                "use": key["use"],
+                "n": key["n"],
+                "e": key["e"]
+            }
+    if rsa_key:
+        try:
+            payload = jwt.decode(
+                token,
+                rsa_key,
+                algorithms=ALGORITHMS,
+                audience=API_AUDIENCE,
+                issuer="https://"+AUTH0_DOMAIN+"/"
+            )
+        except jwt.ExpiredSignatureError:
+            raise AuthError({"code": "token_expired",
+                                "description": "token is expired"}, 401)
+        except jwt.JWTClaimsError:
+            raise AuthError({"code": "invalid_claims",
+                                "description": "incorrect claims, please check the audience and issuer"}, 401)
+        except Exception:
+            raise AuthError({"code": "invalid_header",
+            "description": "Unable to parse authentication token."}, 401)
+
+    _request_ctx_stack.top.current_user = payload
+    return True
 
 def requires_auth(f):
-    """Determines if the Access Token is valid"""
     @wraps(f)
     def decorated(*args, **kwargs):
-        token = get_token_auth_header()
-        jsonurl = urlopen("https://"+AUTH0_DOMAIN+"/.well-known/jwks.json")
-        jwks = json.loads(jsonurl.read())
-        unverified_header = jwt.get_unverified_header(token)
-        rsa_key = {}
-        for key in jwks["keys"]:
-            if key["kid"] == unverified_header["kid"]:
-                rsa_key = {
-                    "kty": key["kty"],
-                    "kid": key["kid"],
-                    "use": key["use"],
-                    "n": key["n"],
-                    "e": key["e"]
-                }
-        if rsa_key:
-            try:
-                payload = jwt.decode(
-                    token,
-                    rsa_key,
-                    algorithms=ALGORITHMS,
-                    audience=API_AUDIENCE,
-                    issuer="https://"+AUTH0_DOMAIN+"/"
-                )
-            except jwt.ExpiredSignatureError:
-                raise AuthError({"code": "token_expired",
-                                 "description": "token is expired"}, 401)
-            except jwt.JWTClaimsError:
-                raise AuthError({"code": "invalid_claims",
-                                 "description": "incorrect claims, please check the audience and issuer"}, 401)
-            except Exception:
-                raise AuthError({"code": "invalid_header",
-                                 "description": "Unable to parse authentication token."}, 401)
-
-            _request_ctx_stack.top.current_user = payload
+        if is_token_valid():
             return f(*args, **kwargs)
         raise AuthError({"code": "invalid_header",
                          "description": "Unable to find appropriate key"}, 401)

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,8 +1,24 @@
 import unittest
 import json
+import os
+import requests
 
 from app import app, db
-from tests.test_utils import auth_headers, require_auth0_secrets
+from auth import AUTH0_DOMAIN, API_AUDIENCE
+from tests.test_utils import require_auth0_secrets
+
+def auth_headers():
+  data = {
+    "client_id": os.environ.get('AUTH0_CLIENT_ID'),
+    "client_secret": os.environ.get('AUTH0_CLIENT_SECRET'),
+    "audience": API_AUDIENCE,
+    "grant_type":"client_credentials"
+  }
+
+  jwt_response = requests.post(f'https://{AUTH0_DOMAIN}/oauth/token', data=data)
+  jwt = json.loads(jwt_response.text)['access_token']
+
+  return {'Authorization': f'Bearer {jwt}'}
 
 class TestAuth(unittest.TestCase):
   def setUp(self):

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -5,7 +5,12 @@ import requests
 
 from app import app, db
 from auth import AUTH0_DOMAIN, API_AUDIENCE
-from tests.test_utils import require_auth0_secrets
+
+def require_auth0_secrets():
+  return unittest.skipIf(
+    not os.environ.get("AUTH0_CLIENT_ID") or not os.environ.get("AUTH0_CLIENT_SECRET"),
+    "Cannot run test without AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET environment variables"
+  )
 
 def auth_headers():
   data = {

--- a/tests/api/test_categories.py
+++ b/tests/api/test_categories.py
@@ -5,7 +5,7 @@ import datetime
 
 from app import app, db
 from models import Category
-from tests.test_utils import clearDatabase, createCategory, auth_headers, require_auth0_secrets
+from tests.test_utils import clearDatabase, createCategory, auth_headers
 
 class CategoriesTestCase(unittest.TestCase):
   def setUp(self):
@@ -86,7 +86,6 @@ class CategoriesTestCase(unittest.TestCase):
 
     self.assertEqual(json_response["text"], "Category does not exist")
 
-  @require_auth0_secrets()
   @patch('auth.is_token_valid', return_value=True)
   def test_post_category(self, mock_auth):
     data = {
@@ -116,7 +115,6 @@ class CategoriesTestCase(unittest.TestCase):
     response = self.client.post("/categories", data={}, headers={})
     self.assertEqual(response.status_code, 401)
 
-  @require_auth0_secrets()
   @patch('auth.is_token_valid', return_value=True)
   def test_put_category(self, mock_auth):
     category = createCategory()
@@ -152,7 +150,6 @@ class CategoriesTestCase(unittest.TestCase):
     response = self.client.put("/categories/1", data={}, headers={})
     self.assertEqual(response.status_code, 401)
 
-  @require_auth0_secrets()
   @patch('auth.is_token_valid', return_value=True)
   def test_put_category_deactivate(self, mock_auth):
     category = createCategory()

--- a/tests/api/test_categories.py
+++ b/tests/api/test_categories.py
@@ -148,7 +148,7 @@ class CategoriesTestCase(unittest.TestCase):
       "deactivated_at": None
     })
 
-  def test_put_category_no_auth(self, mock_auth):
+  def test_put_category_no_auth(self):
     response = self.client.put("/categories/1", data={}, headers={})
     self.assertEqual(response.status_code, 401)
 

--- a/tests/api/test_categories.py
+++ b/tests/api/test_categories.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 import json
 import datetime
 
@@ -86,7 +87,8 @@ class CategoriesTestCase(unittest.TestCase):
     self.assertEqual(json_response["text"], "Category does not exist")
 
   @require_auth0_secrets()
-  def test_post_category(self):
+  @patch('auth.is_token_valid', return_value=True)
+  def test_post_category(self, mock_auth):
     data = {
       "title": "Definition of Domestic Violence",
       "help_text": "This is how a state legally defines the term 'domestic violence'"
@@ -94,6 +96,7 @@ class CategoriesTestCase(unittest.TestCase):
 
     response = self.client.post("/categories", data=data, headers=auth_headers())
     self.assertEqual(response.status_code, 201)
+    mock_auth.assert_called_once()
 
     new_category = Category.query.first()
     self.assertEqual(new_category.title, "Definition of Domestic Violence")
@@ -114,7 +117,8 @@ class CategoriesTestCase(unittest.TestCase):
     self.assertEqual(response.status_code, 401)
 
   @require_auth0_secrets()
-  def test_put_category(self):
+  @patch('auth.is_token_valid', return_value=True)
+  def test_put_category(self, mock_auth):
     category = createCategory()
     db.session.add(category)
     db.session.commit()
@@ -126,6 +130,7 @@ class CategoriesTestCase(unittest.TestCase):
 
     response = self.client.put("/categories/%i" % category.id, data=data, headers=auth_headers())
     self.assertEqual(response.status_code, 200)
+    mock_auth.assert_called_once()
 
     # Refresh category object
     category = Category.query.first()
@@ -143,12 +148,13 @@ class CategoriesTestCase(unittest.TestCase):
       "deactivated_at": None
     })
 
-  def test_put_category_no_auth(self):
+  def test_put_category_no_auth(self, mock_auth):
     response = self.client.put("/categories/1", data={}, headers={})
     self.assertEqual(response.status_code, 401)
 
   @require_auth0_secrets()
-  def test_put_category_deactivate(self):
+  @patch('auth.is_token_valid', return_value=True)
+  def test_put_category_deactivate(self, mock_auth):
     category = createCategory()
     db.session.add(category)
     db.session.commit()
@@ -159,6 +165,7 @@ class CategoriesTestCase(unittest.TestCase):
 
     response = self.client.put("/categories/%i" % category.id, data=data, headers=auth_headers())
     self.assertEqual(response.status_code, 200)
+    mock_auth.assert_called_once()
 
     # Refresh category object
     category = Category.query.first()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,3 @@
-import json
-import os
-import unittest
-
 import models
 
 def clearDatabase(db):
@@ -24,12 +20,6 @@ def createCriterion(category_id):
     recommendation_text="The state's definition of domestic violence should include a framework of economic abuse",
     help_text="This means that the state acknowledges the role that economic control and abuse can play in domestic violence",
     adverse=False
-  )
-
-def require_auth0_secrets():
-  return unittest.skipIf(
-    not os.environ.get("AUTH0_CLIENT_ID") or not os.environ.get("AUTH0_CLIENT_SECRET"),
-    "Cannot run test without AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET environment variables"
   )
 
 def auth_headers():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,8 @@
 import json
 import os
-import requests
 import unittest
 
 import models
-from auth import AUTH0_DOMAIN, API_AUDIENCE
 
 def clearDatabase(db):
   db.session.query(models.Link).delete()
@@ -35,14 +33,4 @@ def require_auth0_secrets():
   )
 
 def auth_headers():
-  data = {
-    "client_id": os.environ.get('AUTH0_CLIENT_ID'),
-    "client_secret": os.environ.get('AUTH0_CLIENT_SECRET'),
-    "audience": API_AUDIENCE,
-    "grant_type":"client_credentials"
-  }
-
-  jwt_response = requests.post(f'https://{AUTH0_DOMAIN}/oauth/token', data=data)
-  jwt = json.loads(jwt_response.text)['access_token']
-
-  return {'Authorization': f'Bearer {jwt}'}
+  return {'Authorization': 'Bearer fake token'}


### PR DESCRIPTION
Closes #60

Refactors the token verification method so that we can mock it in our tests for future POST/PUT endpoints!

I've left `test_auth` to grab a real token from Auth0, so we should just be getting 1 token per test/CI run (if that test file is run).

For example,
`python3 -m unittest` → 1 token
`python3 -m unittest tests/api/test_categories.py` → 0 tokens