### PR TITLE
Clean up database saves

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ from services import (  # noqa: E402
     update_or_create_criterion,
     update_or_create_link,
 )
-from models import Category, Criterion, Link  # noqa: E402
+from models import Category, Criterion, Link, Score  # noqa: E402
 
 
 @app.errorhandler(AuthError)
@@ -200,9 +200,7 @@ def create_score():
         criterion_id=data['criterion_id'],
         state=data['state'],
         meets_criterion=data['meets_criterion'],
-    )
-    db.session.add(score)
-    db.session.commit()
+    ).save()
 
     return jsonify(score.serialize()), 201
 

--- a/app.py
+++ b/app.py
@@ -41,9 +41,6 @@ def get_categories():
 def create_category():
     data = request.get_json()
     category = update_or_create_category(data=data)
-    db.session.add(category)
-    db.session.commit()
-
     return jsonify(category.serialize()), 201
 
 
@@ -68,9 +65,6 @@ def update_category(id_):
         return jsonify(error=404, text=strings.category_not_found), 404
 
     category = update_or_create_category(data, category=category)
-    db.session.add(category)
-    db.session.commit()
-
     return jsonify(category.serialize())
 
 
@@ -95,9 +89,6 @@ def create_criterion():
             return jsonify(text=strings.category_not_found), 404
 
         criterion = update_or_create_criterion(data=data)
-        db.session.add(criterion)
-        db.session.commit()
-
         return jsonify(criterion.serialize()), 201
 
     except Exception as e:
@@ -134,9 +125,6 @@ def update_criterion(id_):
             return jsonify(text=strings.cannot_change_category), 400
 
         update_or_create_criterion(data, criterion)
-        db.session.add(criterion)
-        db.session.commit()
-
         return jsonify(criterion.serialize())
 
     except Exception as e:
@@ -161,9 +149,6 @@ def create_link():
         return jsonify(text=strings.category_not_found), 404
 
     link = update_or_create_link(data=data)
-    db.session.add(link)
-    db.session.commit()
-
     return jsonify(link.serialize()), 201
 
 
@@ -196,9 +181,6 @@ def update_link(id_):
         return jsonify(text=strings.cannot_change_state), 400
 
     link = update_or_create_link(data, link=link)
-    db.session.add(link)
-    db.session.commit()
-
     return jsonify(link.serialize())
 
 

--- a/models.py
+++ b/models.py
@@ -30,6 +30,7 @@ class BaseMixin():
             raise Exception
         return objects
 
+
 class Deactivatable(object):
     active = db.Column(db.Boolean())
     deactivated_at = db.Column(db.DateTime)
@@ -62,6 +63,7 @@ class Category(BaseMixin, Deactivatable, db.Model):
             'help_text': self.help_text,
             'deactivated_at': self.deactivated_at,
         }
+
 
 class Criterion(BaseMixin, Deactivatable, db.Model):
     __tablename__ = 'criteria'

--- a/models.py
+++ b/models.py
@@ -10,6 +10,26 @@ states = [
 ]
 
 
+class BaseMixin():
+    def save(self):
+        db.session.add(self)
+        try:
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+            raise Exception
+        return self
+
+    @classmethod
+    def save_all(cls, objects):
+        db.session.add_all(objects)
+        try:
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+            raise Exception
+        return objects
+
 class Deactivatable(object):
     active = db.Column(db.Boolean())
     deactivated_at = db.Column(db.DateTime)
@@ -19,7 +39,7 @@ class Deactivatable(object):
         self.deactivated_at = datetime.datetime.utcnow()
 
 
-class Category(Deactivatable, db.Model):
+class Category(BaseMixin, Deactivatable, db.Model):
     __tablename__ = 'categories'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -43,8 +63,7 @@ class Category(Deactivatable, db.Model):
             'deactivated_at': self.deactivated_at,
         }
 
-
-class Criterion(Deactivatable, db.Model):
+class Criterion(BaseMixin, Deactivatable, db.Model):
     __tablename__ = 'criteria'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -80,7 +99,7 @@ class Criterion(Deactivatable, db.Model):
         }
 
 
-class Score(db.Model):
+class Score(BaseMixin, db.Model):
     __tablename__ = 'scores'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -116,7 +135,7 @@ class Score(db.Model):
 db.Index('state_criterion_created_at', Score.state, Score.criterion_id, Score.created_at)
 
 
-class Link(Deactivatable, db.Model):
+class Link(BaseMixin, Deactivatable, db.Model):
     __tablename__ = 'links'
 
     id = db.Column(db.Integer, primary_key=True)

--- a/services.py
+++ b/services.py
@@ -17,7 +17,7 @@ def update_or_create_category(data, category=Category()):
     if 'active' in data.keys() and not data['active']:
         category.deactivate()
 
-    return category
+    return category.save()
 
 
 def update_or_create_link(data, link=None):
@@ -41,7 +41,7 @@ def update_or_create_link(data, link=None):
     if 'active' in data.keys() and not data['active']:
         link.deactivate()
 
-    return link
+    return link.save()
 
 
 def update_or_create_criterion(data, criterion=None):
@@ -69,4 +69,4 @@ def update_or_create_criterion(data, criterion=None):
     if 'active' in data and not data['active']:
         criterion.deactivate()
 
-    return criterion
+    return criterion.save()

--- a/tests/api/test_categories.py
+++ b/tests/api/test_categories.py
@@ -28,8 +28,7 @@ class CategoriesTestCase(unittest.TestCase):
             ),
         )
         category2.deactivate()
-        db.session.add_all([category1, category2])
-        db.session.commit()
+        Category.save_all([category1, category2])
 
         response = self.client.get('/categories')
         self.assertEqual(response.status_code, 200)
@@ -69,9 +68,7 @@ class CategoriesTestCase(unittest.TestCase):
         category = Category(
             title='Definition of Domestic Violence',
             help_text="This is how a state legally defines the term 'domestic violence'",
-        )
-        db.session.add(category)
-        db.session.commit()
+        ).save()
 
         response = self.client.get('/categories/%i' % category.id)
         self.assertEqual(response.status_code, 200)
@@ -127,8 +124,6 @@ class CategoriesTestCase(unittest.TestCase):
     @patch('auth.is_token_valid', return_value=True)
     def test_put_category(self, mock_auth):
         category = create_category()
-        db.session.add(category)
-        db.session.commit()
 
         data = {
             'title': 'A New Title',
@@ -166,8 +161,6 @@ class CategoriesTestCase(unittest.TestCase):
     @patch('auth.is_token_valid', return_value=True)
     def test_put_category_deactivate(self, mock_auth):
         category = create_category()
-        db.session.add(category)
-        db.session.commit()
 
         data = {
             'active': False,

--- a/tests/api/test_criteria.py
+++ b/tests/api/test_criteria.py
@@ -12,10 +12,7 @@ from tests.test_utils import clear_database, create_category, create_criterion, 
 class CriteriaTestCase(unittest.TestCase):
     def setUp(self):
         self.client = app.test_client()
-
         self.category = create_category()
-        db.session.add(self.category)
-        db.session.commit()
 
     def tearDown(self):
         clear_database(db)
@@ -50,8 +47,7 @@ class CriteriaTestCase(unittest.TestCase):
         )
 
         criterion2.deactivate()
-        db.session.add_all([criterion1, criterion2])
-        db.session.commit()
+        Criterion.save_all([criterion1, criterion2])
 
         response = self.client.get('/criteria')
         self.assertEqual(response.status_code, 200)
@@ -111,9 +107,7 @@ class CriteriaTestCase(unittest.TestCase):
                 'can play in domestic violence'
             ),
             adverse=False,
-        )
-        db.session.add(criterion)
-        db.session.commit()
+        ).save()
 
         response = self.client.get('/criteria/%i' % criterion.id)
         self.assertEqual(response.status_code, 200)
@@ -213,8 +207,6 @@ class CriteriaTestCase(unittest.TestCase):
     def test_put_criterion(self, mock_auth):
         category_id = self.category.id
         criterion = create_criterion(category_id)
-        db.session.add(criterion)
-        db.session.commit()
 
         data = {
             'title': 'A New Title',
@@ -260,8 +252,6 @@ class CriteriaTestCase(unittest.TestCase):
     def test_put_criterion_change_category(self, mock_auth):
         category_id = self.category.id
         criterion = create_criterion(category_id)
-        db.session.add(criterion)
-        db.session.commit()
 
         data = {'category_id': category_id + 1}
 
@@ -292,8 +282,6 @@ class CriteriaTestCase(unittest.TestCase):
     @patch('auth.is_token_valid', return_value=True)
     def test_put_criterion_deactivate(self, mock_auth):
         criterion = create_criterion(self.category.id)
-        db.session.add(criterion)
-        db.session.commit()
 
         data = {
             'active': False,

--- a/tests/api/test_links.py
+++ b/tests/api/test_links.py
@@ -11,11 +11,7 @@ from tests.test_utils import clear_database, create_category, auth_headers
 class LinksTestCase(unittest.TestCase):
     def setUp(self):
         self.client = app.test_client()
-
         self.category = create_category()
-
-        db.session.add(self.category)
-        db.session.commit()
 
     def tearDown(self):
         clear_database(db)
@@ -37,8 +33,7 @@ class LinksTestCase(unittest.TestCase):
 
         link2.deactivate()
 
-        db.session.add_all([link1, link2])
-        db.session.commit()
+        Link.save_all([link1, link2])
 
         response = self.client.get('/links')
         self.assertEqual(response.status_code, 200)
@@ -81,9 +76,7 @@ class LinksTestCase(unittest.TestCase):
             state='NY',
             text='Section 20 of Statute 39-B',
             url='ny.gov/link/to/statute',
-        )
-        db.session.add(link)
-        db.session.commit()
+        ).save()
 
         response = self.client.get('/links/%i' % link.id)
         self.assertEqual(response.status_code, 200)
@@ -145,9 +138,7 @@ class LinksTestCase(unittest.TestCase):
 
     @patch('auth.is_token_valid', return_value=True)
     def test_put_link(self, mock_auth):
-        link = Link(state='NY', category_id=self.category.id)
-        db.session.add(link)
-        db.session.commit()
+        link = Link(state='NY', category_id=self.category.id).save()
 
         data = {
             'text': 'Section 20 of Statute 39-B',
@@ -183,9 +174,7 @@ class LinksTestCase(unittest.TestCase):
 
     @patch('auth.is_token_valid', return_value=True)
     def test_put_link_deactivate(self, mock_auth):
-        link = Link(state='NY', category_id=self.category.id)
-        db.session.add(link)
-        db.session.commit()
+        link = Link(state='NY', category_id=self.category.id).save()
 
         data = {
             'active': False,

--- a/tests/api/test_scores.py
+++ b/tests/api/test_scores.py
@@ -12,14 +12,8 @@ from tests.test_utils import clear_database, create_category, create_criterion, 
 class ScoresTestCase(unittest.TestCase):
     def setUp(self):
         self.client = app.test_client()
-
         self.category = create_category()
-        db.session.add(self.category)
-        db.session.commit()
-
         self.criterion = create_criterion(self.category.id)
-        db.session.add(self.criterion)
-        db.session.commit()
 
     def tearDown(self):
         clear_database(db)

--- a/tests/models/test_category.py
+++ b/tests/models/test_category.py
@@ -3,7 +3,7 @@ import datetime
 
 from app import app, db
 from models import Category
-from tests.test_utils import clear_database, create_criterion
+from tests.test_utils import clear_database
 
 
 class CategoryTestCase(unittest.TestCase):

--- a/tests/models/test_category.py
+++ b/tests/models/test_category.py
@@ -3,20 +3,16 @@ import datetime
 
 from app import app, db
 from models import Category
-from tests.test_utils import clear_database
+from tests.test_utils import clear_database, create_criterion
 
 
 class CategoryTestCase(unittest.TestCase):
     def setUp(self):
         self.client = app.test_client()
-
         self.category = Category(
             title='Definition of Domestic Violence',
             help_text="This is how a state legally defines the term 'domestic violence'",
-        )
-
-        db.session.add(self.category)
-        db.session.commit()
+        ).save()
 
     def tearDown(self):
         clear_database(db)

--- a/tests/models/test_criterion.py
+++ b/tests/models/test_criterion.py
@@ -11,9 +11,6 @@ class CriterionTestCase(unittest.TestCase):
         self.client = app.test_client()
 
         self.category = create_category()
-        db.session.add(self.category)
-        db.session.commit()
-
         self.criterion = Criterion(
             category_id=self.category.id,
             title='Includes economic abuse framework',
@@ -26,10 +23,7 @@ class CriterionTestCase(unittest.TestCase):
                 'can play in domestic violence'
             ),
             adverse=False,
-        )
-
-        db.session.add(self.criterion)
-        db.session.commit()
+        ).save()
 
     def tearDown(self):
         clear_database(db)

--- a/tests/models/test_link.py
+++ b/tests/models/test_link.py
@@ -9,18 +9,12 @@ from tests.test_utils import clear_database, create_category
 class LinkTestCase(unittest.TestCase):
     def setUp(self):
         self.category = create_category()
-        db.session.add(self.category)
-        db.session.commit()
-
         self.link = Link(
             category_id=self.category.id,
             state='NY',
             text='Section 20 of Statute 39-B',
             url='ny.gov/link/to/statute',
-        )
-
-        db.session.add(self.link)
-        db.session.commit()
+        ).save()
 
     def tearDown(self):
         clear_database(db)

--- a/tests/models/test_score.py
+++ b/tests/models/test_score.py
@@ -9,21 +9,12 @@ from tests.test_utils import clear_database, create_category, create_criterion
 class ScoreTestCase(unittest.TestCase):
     def setUp(self):
         self.category = create_category()
-        db.session.add(self.category)
-        db.session.commit()
-
         self.criterion = create_criterion(self.category.id)
-        db.session.add(self.criterion)
-        db.session.commit()
-
         self.score = Score(
             criterion_id=self.criterion.id,
             state='NY',
             meets_criterion=True,
-        )
-
-        db.session.add(self.score)
-        db.session.commit()
+        ).save()
 
     def tearDown(self):
         clear_database(db)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ def create_category():
     return models.Category(
         title='Definition of Domestic Violence',
         help_text="This is how a state legally defines the term 'domestic violence'",
-    )
+    ).save()
 
 
 def create_criterion(category_id):
@@ -29,7 +29,7 @@ def create_criterion(category_id):
             'play in domestic violence'
         ),
         adverse=False
-    )
+    ).save()
 
 
 def auth_headers():


### PR DESCRIPTION
A little code cleanup to remove repetitive `db.session.add()` and `db.session.commit()` calls.

Also moved the logic for saving records to the `create_model` service/utility functions! 