### PR TITLE
Add withCriteria param to GET categories endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,8 +31,10 @@ def handle_auth_error(ex):
 
 @app.route('/categories', methods=['GET'])
 def get_categories():
+    with_criteria = request.args.get('withCriteria') == 'true'
+
     categories = Category.query.all()
-    return jsonify([category.serialize() for category in categories])
+    return jsonify([category.serialize(with_criteria) for category in categories])
 
 
 @app.route('/categories', methods=['POST'])
@@ -51,7 +53,8 @@ def get_category(id_):
     if category is None:
         return jsonify(error=404, text=strings.category_not_found), 404
 
-    return jsonify(category.serialize())
+    with_criteria = request.args.get('withCriteria') == 'true'
+    return jsonify(category.serialize(with_criteria))
 
 
 @app.route('/categories/<id_>', methods=['PUT'])

--- a/models.py
+++ b/models.py
@@ -46,6 +46,7 @@ class Category(BaseMixin, Deactivatable, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String())
     help_text = db.Column(db.String())
+    criteria = db.relationship('Criterion', backref='category', lazy=True)
 
     def __init__(self, title=None, help_text=None):
         self.title = title
@@ -55,14 +56,19 @@ class Category(BaseMixin, Deactivatable, db.Model):
     def __repr__(self):
         return '<id {}>'.format(self.id)
 
-    def serialize(self):
-        return {
+    def serialize(self, with_criteria=False):
+        data = {
             'id': self.id,
             'title': self.title,
             'active': self.active,
             'help_text': self.help_text,
             'deactivated_at': self.deactivated_at,
         }
+
+        if with_criteria:
+            data['criteria'] = [criterion.serialize() for criterion in self.criteria]
+
+        return data
 
 
 class Criterion(BaseMixin, Deactivatable, db.Model):

--- a/tests/api/test_categories.py
+++ b/tests/api/test_categories.py
@@ -55,6 +55,7 @@ class CategoriesTestCase(unittest.TestCase):
 
         # Assert that the expected results are a subset of the actual results
         self.assertTrue(category_2_expected.items() <= json_response[1].items())
+        self.assertTrue(isinstance(json_response[1]['deactivated_at'], str))
 
     def test_get_categories_with_criteria(self):
         category = create_category()

--- a/tests/api/test_categories.py
+++ b/tests/api/test_categories.py
@@ -5,7 +5,7 @@ import datetime
 
 from app import app, db
 from models import Category
-from tests.test_utils import clear_database, create_category, auth_headers
+from tests.test_utils import clear_database, create_category, create_criterion, auth_headers
 
 
 class CategoriesTestCase(unittest.TestCase):
@@ -55,7 +55,25 @@ class CategoriesTestCase(unittest.TestCase):
 
         # Assert that the expected results are a subset of the actual results
         self.assertTrue(category_2_expected.items() <= json_response[1].items())
-        self.assertTrue(isinstance(json_response[1]['deactivated_at'], str))
+
+    def test_get_categories_with_criteria(self):
+        category = create_category()
+        criterion = create_criterion(category.id)
+
+        response = self.client.get('/categories?withCriteria=true')
+        self.assertEqual(response.status_code, 200)
+
+        json_response = json.loads(response.data)
+        self.assertEqual(len(json_response), 1)
+
+        self.assertEqual(json_response[0], {
+            'id': category.id,
+            'title': 'Definition of Domestic Violence',
+            'help_text': "This is how a state legally defines the term 'domestic violence'",
+            'active': True,
+            'deactivated_at': None,
+            'criteria': [criterion.serialize()],
+        })
 
     def test_get_categories_empty(self):
         response = self.client.get('/categories')
@@ -80,6 +98,26 @@ class CategoriesTestCase(unittest.TestCase):
             'help_text': "This is how a state legally defines the term 'domestic violence'",
             'active': True,
             'deactivated_at': None,
+        })
+
+    def test_get_category_with_criteria(self):
+        category = Category(
+            title='Definition of Domestic Violence',
+            help_text="This is how a state legally defines the term 'domestic violence'",
+        ).save()
+        criterion = create_criterion(category.id)
+
+        response = self.client.get('/categories/%i?withCriteria=true' % category.id)
+        self.assertEqual(response.status_code, 200)
+        json_response = json.loads(response.data.decode('utf-8'))
+
+        self.assertEqual(json_response, {
+            'id': category.id,
+            'title': 'Definition of Domestic Violence',
+            'help_text': "This is how a state legally defines the term 'domestic violence'",
+            'active': True,
+            'deactivated_at': None,
+            'criteria': [criterion.serialize()],
         })
 
     def test_get_category_doesnt_exist(self):

--- a/tests/models/test_category.py
+++ b/tests/models/test_category.py
@@ -3,7 +3,7 @@ import datetime
 
 from app import app, db
 from models import Category
-from tests.test_utils import clear_database
+from tests.test_utils import clear_database, create_criterion
 
 
 class CategoryTestCase(unittest.TestCase):
@@ -13,6 +13,8 @@ class CategoryTestCase(unittest.TestCase):
             title='Definition of Domestic Violence',
             help_text="This is how a state legally defines the term 'domestic violence'",
         ).save()
+        self.criterion1 = create_criterion(self.category.id)
+        self.criterion2 = create_criterion(self.category.id)
 
     def tearDown(self):
         clear_database(db)
@@ -35,6 +37,22 @@ class CategoryTestCase(unittest.TestCase):
                 'deactivated_at': None,
             },
             self.category.serialize()
+        )
+
+    def test_serialize_with_criteria(self):
+        self.assertEqual(
+            {
+                'id': self.category.id,
+                'title': 'Definition of Domestic Violence',
+                'help_text': "This is how a state legally defines the term 'domestic violence'",
+                'active': True,
+                'deactivated_at': None,
+                'criteria': [
+                    self.criterion1.serialize(),
+                    self.criterion2.serialize(),
+                ]
+            },
+            self.category.serialize(with_criteria=True)
         )
 
     def test_deactivate(self):

--- a/tests/models/test_category.py
+++ b/tests/models/test_category.py
@@ -3,7 +3,7 @@ import datetime
 
 from app import app, db
 from models import Category
-from tests.test_utils import clear_database
+from tests.test_utils import clear_database, create_criterion
 
 
 class CategoryTestCase(unittest.TestCase):

--- a/tests/models/test_category.py
+++ b/tests/models/test_category.py
@@ -3,7 +3,7 @@ import datetime
 
 from app import app, db
 from models import Category
-from tests.test_utils import clear_database, create_criterion
+from tests.test_utils import clear_database
 
 
 class CategoryTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR lets the client call GET `/categories?withCriteria=true` or `/categories/i?withCriteria=true` to get a category's criteria in the response body.

This branch works off #72, but should be merged to main (I'll try not to forget this time 😅)

Closes #38 
Closes #39