### PR TITLE
Standardize API error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,9 +109,6 @@ def create_criterion():
     criterion = update_or_create_criterion(data=data)
     return jsonify(criterion.serialize()), 201
 
-    # except Exception as e:
-    #     return jsonify(text=str(e)), 500
-
 
 @app.route('/criteria/<id_>', methods=['GET'])
 def get_criterion(id_):

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import strings
 from auth import AuthError, requires_auth
 import os
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, abort
 from flask_sqlalchemy import SQLAlchemy
 from dotenv import load_dotenv
 from flask_cors import cross_origin
@@ -23,11 +23,29 @@ from services import (  # noqa: E402
 from models import Category, Criterion, Link, Score, states  # noqa: E402
 
 
+@app.errorhandler(400)
+def handle_bad_request(e):
+    return jsonify(description=str(e.description)), 400
+
+
 @app.errorhandler(AuthError)
-def handle_auth_error(ex):
-    response = jsonify(ex.error)
-    response.status_code = ex.status_code
-    return response
+def handle_auth_error(e):
+    return jsonify(e.error), 401
+
+
+@app.errorhandler(404)
+def handle_not_found(e):
+    return jsonify(description=str(e.description)), 404
+
+
+@app.errorhandler(405)
+def handle_not_allowed(e):
+    return jsonify(description=str(e.description)), 405
+
+
+@app.errorhandler(Exception)
+def handle_server_error(e):
+    return jsonify(description='Internal server error'), 500
 
 
 @app.route('/categories', methods=['GET'])
@@ -52,7 +70,7 @@ def get_category(id_):
     category = Category.query.filter_by(id=id_).first()
 
     if category is None:
-        return jsonify(error=404, text=strings.category_not_found), 404
+        abort(404, strings.category_not_found)
 
     with_criteria = request.args.get('withCriteria') == 'true'
     return jsonify(category.serialize(with_criteria))
@@ -66,7 +84,7 @@ def update_category(id_):
     data = request.get_json()
 
     if category is None:
-        return jsonify(error=404, text=strings.category_not_found), 404
+        abort(404, strings.category_not_found)
 
     category = update_or_create_category(data, category=category)
     return jsonify(category.serialize())
@@ -74,65 +92,54 @@ def update_category(id_):
 
 @app.route('/criteria', methods=['GET'])
 def get_criteria():
-    try:
-        criteria = Criterion.query.all()
-        return jsonify([criterion.serialize() for criterion in criteria])
-    except Exception as e:
-        return(str(e))
+    criteria = Criterion.query.all()
+    return jsonify([criterion.serialize() for criterion in criteria])
 
 
 @app.route('/criteria', methods=['POST'])
 @cross_origin(headers=['Content-Type', 'Authorization'])
 @requires_auth
 def create_criterion():
-    try:
-        data = request.get_json()
+    data = request.get_json()
 
-        category = Category.query.filter_by(id=data.get('category_id')).first()
-        if category is None:
-            return jsonify(text=strings.category_not_found), 404
+    category = Category.query.filter_by(id=data.get('category_id')).first()
+    if category is None:
+        abort(404, strings.category_not_found)
 
-        criterion = update_or_create_criterion(data=data)
-        return jsonify(criterion.serialize()), 201
+    criterion = update_or_create_criterion(data=data)
+    return jsonify(criterion.serialize()), 201
 
-    except Exception as e:
-        return jsonify(text=str(e)), 500
+    # except Exception as e:
+    #     return jsonify(text=str(e)), 500
 
 
 @app.route('/criteria/<id_>', methods=['GET'])
 def get_criterion(id_):
-    try:
-        criterion = Criterion.query.filter_by(id=id_).first()
+    criterion = Criterion.query.filter_by(id=id_).first()
 
-        if criterion is None:
-            return jsonify(text=strings.criterion_not_found), 404
+    if criterion is None:
+        abort(404, strings.criterion_not_found)
 
-        return jsonify(criterion.serialize())
-    except Exception as e:
-        return(str(e))
+    return jsonify(criterion.serialize())
 
 
 @app.route('/criteria/<id_>', methods=['PUT'])
 @cross_origin(headers=['Content-Type', 'Authorization'])
 @requires_auth
 def update_criterion(id_):
-    try:
-        criterion = Criterion.query.filter_by(id=id_).first()
+    criterion = Criterion.query.filter_by(id=id_).first()
 
-        if criterion is None:
-            return jsonify(text=strings.criterion_not_found), 404
+    if criterion is None:
+        abort(404, strings.criterion_not_found)
 
-        data = request.get_json()
+    data = request.get_json()
 
-        category_id = data.get('category_id')
-        if category_id and category_id != criterion.category_id:
-            return jsonify(text=strings.cannot_change_category), 400
+    category_id = data.get('category_id')
+    if category_id and category_id != criterion.category_id:
+        abort(400, strings.cannot_change_category)
 
-        update_or_create_criterion(data, criterion)
-        return jsonify(criterion.serialize())
-
-    except Exception as e:
-        return jsonify(text=str(e)), 500
+    update_or_create_criterion(data, criterion)
+    return jsonify(criterion.serialize())
 
 
 @app.route('/links', methods=['GET'])
@@ -150,7 +157,7 @@ def create_link():
 
     category = Category.query.filter_by(id=data.get('category_id')).first()
     if category is None:
-        return jsonify(text=strings.category_not_found), 404
+        abort(404, strings.category_not_found)
 
     link = update_or_create_link(data=data)
     return jsonify(link.serialize()), 201
@@ -161,7 +168,7 @@ def get_link(id_):
     link = Link.query.filter_by(id=id_).first()
 
     if link is None:
-        return jsonify(error=404, text=strings.link_not_found), 404
+        abort(404, strings.link_not_found)
 
     return jsonify(link.serialize())
 
@@ -174,15 +181,15 @@ def update_link(id_):
     data = request.get_json()
 
     if link is None:
-        return jsonify(error=404, text=strings.link_not_found), 404
+        abort(404, strings.link_not_found)
 
     category_id = data.get('category_id')
     if category_id and category_id != link.category_id:
-        return jsonify(text=strings.cannot_change_category), 400
+        abort(400, strings.cannot_change_category)
 
     state = data.get('state')
     if state and state != link.state:
-        return jsonify(text=strings.cannot_change_state), 400
+        abort(400, strings.cannot_change_state)
 
     link = update_or_create_link(data, link=link)
     return jsonify(link.serialize())
@@ -196,7 +203,7 @@ def create_score():
 
     criterion = Criterion.query.filter_by(id=data.get('criterion_id')).first()
     if criterion is None:
-        return jsonify(text=strings.criterion_not_found), 404
+        abort(404, strings.criterion_not_found)
 
     # TODO: Raise an appropriate error if category_id and state are not present
     #  (see issue #57)
@@ -212,7 +219,7 @@ def create_score():
 @app.route('/states/<state_>', methods=['GET'])
 def get_state(state_):
     if state_ not in states:
-        return jsonify(text=strings.invalid_state), 400
+        abort(400, strings.invalid_state)
 
     state = get_state_information(state_)
 

--- a/auth.py
+++ b/auth.py
@@ -12,9 +12,8 @@ ALGORITHMS = ['RS256']
 
 
 class AuthError(Exception):
-    def __init__(self, error, status_code):
+    def __init__(self, error):
         self.error = error
-        self.status_code = status_code
 
 
 def get_token_auth_header():
@@ -27,8 +26,7 @@ def get_token_auth_header():
             {
                 'code': 'authorization_header_missing',
                 'description': 'Authorization header is expected',
-            },
-            401,
+            }
         )
 
     parts = auth.split()
@@ -38,24 +36,21 @@ def get_token_auth_header():
             {
                 'code': 'invalid_header',
                 'description': 'Authorization header must start with Bearer',
-            },
-            401,
+            }
         )
     elif len(parts) == 1:
         raise AuthError(
             {
                 'code': 'invalid_header',
                 'description': 'Token not found',
-            },
-            401,
+            }
         )
     elif len(parts) > 2:
         raise AuthError(
             {
                 'code': 'invalid_header',
                 'description': 'Authorization header must be Bearer token',
-            },
-            401,
+            }
         )
 
     token = parts[1]
@@ -94,24 +89,21 @@ def is_token_valid():
                 {
                     'code': 'token_expired',
                     'description': 'token is expired',
-                },
-                401,
+                }
             )
         except jwt.JWTClaimsError:
             raise AuthError(
                 {
                     'code': 'invalid_claims',
                     'description': 'incorrect claims, please check the audience and issuer',
-                },
-                401,
+                }
             )
         except Exception:
             raise AuthError(
                 {
                     'code': 'invalid_header',
                     'description': 'Unable to parse authentication token.',
-                },
-                401,
+                }
             )
 
         _request_ctx_stack.top.current_user = payload
@@ -129,7 +121,6 @@ def requires_auth(f):
             {
                 'code': 'invalid_header',
                 'description': 'Unable to find appropriate key',
-            },
-            401,
+            }
         )
     return decorated

--- a/tests/api/test_categories.py
+++ b/tests/api/test_categories.py
@@ -124,9 +124,8 @@ class CategoriesTestCase(unittest.TestCase):
     def test_get_category_doesnt_exist(self):
         response = self.client.get('/categories/1')
         self.assertEqual(response.status_code, 404)
-        json_response = json.loads(response.data.decode('utf-8'))
-
-        self.assertEqual(json_response['text'], 'Category does not exist')
+        json_response = json.loads(response.data)
+        self.assertEqual(json_response['description'], 'Category does not exist')
 
     @patch('auth.is_token_valid', return_value=True)
     def test_post_category(self, mock_auth):

--- a/tests/api/test_criteria.py
+++ b/tests/api/test_criteria.py
@@ -131,9 +131,8 @@ class CriteriaTestCase(unittest.TestCase):
     def test_get_criterion_doesnt_exist(self):
         response = self.client.get('/criteria/1')
         self.assertEqual(response.status_code, 404)
-        json_response = json.loads(response.data.decode('utf-8'))
-
-        self.assertEqual(json_response['text'], 'Criterion does not exist')
+        json_response = json.loads(response.data)
+        self.assertEqual(json_response['description'], strings.criterion_not_found)
 
     @patch('auth.is_token_valid', return_value=True)
     def test_post_criterion(self, mock_auth):
@@ -197,7 +196,7 @@ class CriteriaTestCase(unittest.TestCase):
         mock_auth.assert_called_once()
 
         json_response = json.loads(response.data)
-        self.assertEqual(json_response['text'], strings.category_not_found)
+        self.assertEqual(json_response['description'], strings.category_not_found)
 
     def test_post_criterion_no_auth(self):
         response = self.client.post('/criteria', data={}, headers={})
@@ -264,7 +263,7 @@ class CriteriaTestCase(unittest.TestCase):
         mock_auth.assert_called_once()
 
         json_response = json.loads(response.data)
-        self.assertEqual(json_response['text'], strings.cannot_change_category)
+        self.assertEqual(json_response['description'], strings.cannot_change_category)
 
     def test_put_category_no_auth(self):
         response = self.client.put('/criteria/1', json={}, headers={})
@@ -277,7 +276,7 @@ class CriteriaTestCase(unittest.TestCase):
         mock_auth.assert_called_once()
 
         json_response = json.loads(response.data)
-        self.assertEqual(json_response['text'], strings.criterion_not_found)
+        self.assertEqual(json_response['description'], strings.criterion_not_found)
 
     @patch('auth.is_token_valid', return_value=True)
     def test_put_criterion_deactivate(self, mock_auth):

--- a/tests/api/test_links.py
+++ b/tests/api/test_links.py
@@ -6,6 +6,7 @@ import datetime
 from app import app, db
 from models import Category, Link
 from tests.test_utils import clear_database, create_category, auth_headers
+import strings
 
 
 class LinksTestCase(unittest.TestCase):
@@ -95,9 +96,8 @@ class LinksTestCase(unittest.TestCase):
     def test_get_link_doesnt_exist(self):
         response = self.client.get('/links/1')
         self.assertEqual(response.status_code, 404)
-        json_response = json.loads(response.data.decode('utf-8'))
-
-        self.assertEqual(json_response['text'], 'Link does not exist')
+        json_response = json.loads(response.data)
+        self.assertEqual(json_response['description'], strings.link_not_found)
 
     @patch('auth.is_token_valid', return_value=True)
     def test_post_link(self, mock_auth):

--- a/tests/api/test_scores.py
+++ b/tests/api/test_scores.py
@@ -57,7 +57,7 @@ class ScoresTestCase(unittest.TestCase):
         mock_auth.assert_called_once()
 
         json_response = json.loads(response.data)
-        self.assertEqual(json_response['text'], strings.criterion_not_found)
+        self.assertEqual(json_response['description'], strings.criterion_not_found)
 
     def test_post_score_no_auth(self):
         response = self.client.post('/scores', data={}, headers={})


### PR DESCRIPTION
Closes #57

This PR standardizes our errors in the app! It seems we have 5 main errors: 400, 401, 404, 405, and 500 (as a catch-all). Let me know if I've missed any, or if we want to rethink this!

All error responses will have a `data['description']` field for the client to see a more detailed message.

I'll implement the error handling for missing fields in #66!