### PR TITLE
Raise errors for missing/invalid references

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,6 +1,7 @@
 import datetime
 from app import db
 from sqlalchemy.orm import validates
+import strings
 
 states = [
     'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DC', 'DE', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA',
@@ -94,6 +95,12 @@ class Criterion(BaseMixin, Deactivatable, db.Model):
     def __repr__(self):
         return '<id {}>'.format(self.id)
 
+    @validates('category_id')
+    def validate_category(self, key, value):
+        if Category.query.get(value) is None:
+            raise ValueError(strings.category_not_found)
+        return value
+
     def serialize(self):
         return {
             'id': self.id,
@@ -125,9 +132,16 @@ class Score(BaseMixin, db.Model):
     def __repr__(self):
         return '<id {}>'.format(self.id)
 
+    @validates('criterion_id')
+    def validate_criterion(self, key, value):
+        if Criterion.query.get(value) is None:
+            raise ValueError(strings.criterion_not_found)
+        return value
+
     @validates('state')
     def validate_state(self, key, value):
-        assert value in states
+        if value not in states:
+            raise ValueError(strings.invalid_state)
         return value
 
     def serialize(self):
@@ -161,9 +175,16 @@ class Link(BaseMixin, Deactivatable, db.Model):
     def __repr__(self):
         return '<id {}>'.format(self.id)
 
+    @validates('category_id')
+    def validate_category(self, key, value):
+        if Category.query.get(value) is None:
+            raise ValueError(strings.category_not_found)
+        return value
+
     @validates('state')
     def validate_state(self, key, value):
-        assert value in states
+        if value not in states:
+            raise ValueError(strings.invalid_state)
         return value
 
     def serialize(self):

--- a/services.py
+++ b/services.py
@@ -1,6 +1,7 @@
 from models import Category, Criterion, Link, Score
 from app import db
 from sqlalchemy import func
+import strings
 
 
 def update_or_create_category(data, category=Category()):
@@ -27,12 +28,17 @@ def update_or_create_link(data, link=None):
     Takes a dict of data where the keys are fields of the link model.
     Valid keys are category_id, state, text, url, and active. The 'active'
     key only uses a False value to deactivate the link.
-    '''
 
+    Once created, a link's category or state cannot be changed.
+    '''
+    category_id = data.get('category_id')
+    state = data.get('state')
     if link is None:
-        # TODO: Raise an appropriate error if category_id and state are not present
-        #  (see issue #57)
-        link = Link(category_id=data['category_id'], state=data['state'])
+        link = Link(category_id=category_id, state=state)
+    elif category_id and category_id != link.category_id:
+        raise ValueError(strings.cannot_change_category)
+    elif state and state != link.state:
+        raise ValueError(strings.cannot_change_state)
 
     if 'text' in data.keys():
         link.text = data['text']
@@ -51,12 +57,14 @@ def update_or_create_criterion(data, criterion=None):
     Takes a dict of data where the keys are fields of the criterion model.
     Valid keys are category_id, title, recommendation_text, help_text, adverse,
     and active. The 'active' key only uses a False value.
-    '''
 
+    Once created, a criterion's category cannot be changed.
+    '''
+    category_id = data.get('category_id')
     if criterion is None:
-        # TODO: Raise an appropriate error if category_id and state are not present
-        #  (see issue #57)
-        criterion = Criterion(category_id=data['category_id'])
+        criterion = Criterion(category_id=category_id)
+    elif category_id and category_id != criterion.category_id:
+        raise ValueError(strings.cannot_change_category)
 
     if 'title' in data:
         criterion.title = data['title']

--- a/tests/models/test_criterion.py
+++ b/tests/models/test_criterion.py
@@ -3,6 +3,7 @@ import datetime
 
 from app import app, db
 from models import Criterion
+from strings import category_not_found
 from tests.test_utils import clear_database, create_category
 
 
@@ -43,6 +44,23 @@ class CriterionTestCase(unittest.TestCase):
         ),
         self.assertTrue(self.criterion.active)
         self.assertFalse(self.criterion.adverse)
+
+    def test_init_invalid_category(self):
+        with self.assertRaises(ValueError) as e:
+            Criterion(
+                category_id=0,
+                title='Includes economic abuse framework',
+                recommendation_text=(
+                    "The state's definition of domestic violence should include a framework of "
+                    'economic abuse'
+                ),
+                help_text=(
+                    'This means that the state acknowledges the role that economic control and '
+                    'abuse can play in domestic violence'
+                ),
+                adverse=False,
+            )
+        self.assertEqual(str(e.exception), category_not_found)
 
     def test_serialize(self):
         self.assertEqual(

--- a/tests/models/test_link.py
+++ b/tests/models/test_link.py
@@ -3,6 +3,7 @@ import datetime
 
 from app import db
 from models import Link
+from strings import category_not_found, invalid_state
 from tests.test_utils import clear_database, create_category
 
 
@@ -26,14 +27,25 @@ class LinkTestCase(unittest.TestCase):
         self.assertEqual(self.link.url, 'ny.gov/link/to/statute')
         self.assertTrue(self.category.active)
 
+    def test_init_invalid_category(self):
+        with self.assertRaises(ValueError) as e:
+            Link(
+                category_id=0,
+                state='NY',
+                text='Section 20 of Statute 39-B',
+                url='ny.gov/link/to/statute',
+            )
+        self.assertEqual(str(e.exception), category_not_found)
+
     def test_init_invalid_state_code(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError) as e:
             Link(
                 category_id=self.category.id,
                 state='fake-state',
                 text='Section 20 of Statute 39-B',
                 url='ny.gov/link/to/statute',
             )
+        self.assertEqual(str(e.exception), invalid_state)
 
     def test_serialize(self):
         self.assertEqual(

--- a/tests/models/test_score.py
+++ b/tests/models/test_score.py
@@ -3,6 +3,7 @@ import datetime
 
 from app import db
 from models import Score
+from strings import criterion_not_found, invalid_state
 from tests.test_utils import clear_database, create_category, create_criterion
 
 
@@ -26,13 +27,23 @@ class ScoreTestCase(unittest.TestCase):
         self.assertTrue(isinstance(self.score.created_at, datetime.datetime))
         self.assertTrue(self.score.created_at < datetime.datetime.utcnow())
 
+    def test_init_invalid_criterion(self):
+        with self.assertRaises(ValueError) as e:
+            Score(
+                criterion_id=0,
+                state='NY',
+                meets_criterion=True,
+            )
+        self.assertEqual(str(e.exception), criterion_not_found)
+
     def test_init_invalid_state_code(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError) as e:
             Score(
                 criterion_id=self.criterion.id,
                 state='fake-state',
                 meets_criterion=True,
             )
+        self.assertEqual(str(e.exception), invalid_state)
 
     def test_serialize(self):
         expected_result = {


### PR DESCRIPTION
Closes #66

Adding validations on the model level, so that missing/invalid references raise a `ValueError`, which returns a 400 to the client!

This is based off #76, and should be merged to main.