### PR TITLE
Add the /states endpoint to the API

### DIFF
--- a/app.py
+++ b/app.py
@@ -240,6 +240,12 @@ def get_state(code_):
     return jsonify(state.serialize()), 200
 
 
+@app.route('/states', methods=['GET'])
+def get_states():
+    states = State.query.all()
+    return jsonify([state.serialize() for state in states]), 200
+
+
 # This doesn't need authentication
 @app.route('/api/public')
 @cross_origin(headers=['Content-Type', 'Authorization'])

--- a/tests/api/test_states.py
+++ b/tests/api/test_states.py
@@ -31,3 +31,25 @@ class StatesTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         json_response = json.loads(response.data)
         self.assertEqual(json_response['description'], strings.invalid_state)
+
+    def test_get_states(self):
+        state_ny = State(
+            code='NY',
+            name='New York',
+            innovative_idea='Innovative idea',
+            honorable_mention='Honorable mention',
+        ).save()
+
+        state_ca = State(
+            code='CA',
+            name='California',
+            innovative_idea='Innovative idea',
+            honorable_mention='Honorable mention',
+        ).save()
+
+        response = self.client.get('/states')
+        self.assertEqual(response.status_code, 200)
+        json_response = json.loads(response.data)
+        self.assertEqual(len(json_response), 2)
+        self.assertEqual(json_response[0], state_ny.serialize())
+        self.assertEqual(json_response[1], state_ca.serialize())


### PR DESCRIPTION
Closes #41. Allows the user to get information about all states at the `/states` endpoint.