### PR TITLE
When a new criterion is created, set the default value of adverse to False

### DIFF
--- a/models.py
+++ b/models.py
@@ -183,7 +183,7 @@ class Criterion(BaseMixin, Deactivatable, db.Model):
         title=None,
         recommendation_text=None,
         help_text=None,
-        adverse=None,
+        adverse=False,
     ):
         self.subcategory_id = subcategory_id
         self.title = title

--- a/tests/models/test_criterion.py
+++ b/tests/models/test_criterion.py
@@ -46,6 +46,10 @@ class CriterionTestCase(unittest.TestCase):
         self.assertTrue(self.criterion.active)
         self.assertFalse(self.criterion.adverse)
 
+    def test_init_default_adverse_value(self):
+        criterion = Criterion(subcategory_id=self.subcategory.id)
+        self.assertFalse(criterion.adverse)
+
     def test_init_invalid_subcategory(self):
         with self.assertRaises(ValueError) as e:
             Criterion(


### PR DESCRIPTION
I want to make sure that the `adverse` field is always a boolean if we say it's going to be a boolean, so I propose providing False as a default value.