### PR TITLE
Implement web hook for CMS

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,6 @@
 export APP_SETTINGS="config.DevelopmentConfig"
 export DATABASE_URL="postgresql://localhost/freefrom_map_dev"
+export CMS_URL="http://freefrom-cms.nitro"
 
 # Ask for this information in #proj-freefrom-map-dev in Slack
 export AUTH0_CLIENT_ID=""

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 import strings
 from auth import AuthError, requires_auth
+from providers import get_categories_from_cms, get_states_from_cms
+
 import os
 from flask import Flask, request, jsonify, abort
 from flask_sqlalchemy import SQLAlchemy
@@ -16,6 +18,7 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 
 import services  # noqa: E402
+import data.importer  # noqa: E402
 
 from models import (  # noqa: E402
     Category,
@@ -228,6 +231,18 @@ def submit_form(name_):
     data = request.get_json()
     form = services.submit_form_to_google(name_, data)
     return form, 201
+
+
+@app.route('/import', methods=['POST'])
+@cross_origin(headers=['Content-Type', 'Authorization'])
+def import_data():
+    categories_json = get_categories_from_cms()
+    states_json = get_states_from_cms()
+
+    data.importer.import_categories(categories_json)
+    data.importer.import_states(states_json)
+
+    return jsonify({'success': True}), 200
 
 
 # This doesn't need authentication

--- a/data/importer.py
+++ b/data/importer.py
@@ -1,0 +1,49 @@
+from models import (
+    Category,
+    Criterion,
+    State,
+)
+
+from services import (
+    update_or_create_category,
+    update_or_create_criterion,
+    update_state
+)
+
+
+def import_categories(categories_json):
+    return list(map(import_category, categories_json))
+
+
+def import_states(states_json):
+    return list(map(import_state, states_json))
+
+
+def import_category(category_json):
+    category = Category.query.get(category_json['id'])
+
+    category = update_or_create_category(category_json, category)
+
+    for criterion_json in category_json['criteria']:
+        criterion_json['category_id'] = category_json['id']
+        import_criterion(criterion_json, category_json['id'])
+
+    return category.serialize(with_criteria=True)
+
+
+def import_criterion(criterion_json, category_id):
+    criterion = Criterion.query.get(criterion_json['id'])
+    criterion = update_or_create_criterion(criterion_json, criterion=criterion)
+
+    return criterion.serialize()
+
+
+def import_state(state_json):
+    state = State.query.get(state_json['code'])
+
+    if state is None:
+        raise Exception(f'{state_json["code"]} is not a valid state code')
+
+    state = update_state(state_json, state)
+
+    return state.serialize()

--- a/data/importer.py
+++ b/data/importer.py
@@ -26,12 +26,12 @@ def import_category(category_json):
 
     for criterion_json in category_json['criteria']:
         criterion_json['category_id'] = category_json['id']
-        import_criterion(criterion_json, category_json['id'])
+        import_criterion(criterion_json)
 
     return category.serialize(with_criteria=True)
 
 
-def import_criterion(criterion_json, category_id):
+def import_criterion(criterion_json):
     criterion = Criterion.query.get(criterion_json['id'])
     criterion = update_or_create_criterion(criterion_json, criterion=criterion)
 

--- a/models.py
+++ b/models.py
@@ -120,7 +120,8 @@ class Category(BaseMixin, Deactivatable, db.Model):
     help_text = db.Column(db.String())
     criteria = db.relationship('Criterion', backref='category', lazy=True)
 
-    def __init__(self, title=None, help_text=None):
+    def __init__(self, id=None, title=None, help_text=None):
+        self.id = id
         self.title = title
         self.help_text = help_text
         self.active = True
@@ -345,7 +346,8 @@ class Link(BaseMixin, Deactivatable, db.Model):
         'polymorphic_identity': 'link'
     }
 
-    def __init__(self, category_id, state, text=None, url=None):
+    def __init__(self, category_id, state, text=None, url=None, id=None):
+        self.id = id
         self.category_id = category_id
         self.state = state
         self.text = text
@@ -393,8 +395,8 @@ class HonorableMention(Link):
         'polymorphic_identity': 'honorable_mention'
     }
 
-    def __init__(self, category_id, state, text=None, url=None, description=None):
-        super().__init__(category_id, state, text, url)
+    def __init__(self, category_id, state, text=None, url=None, description=None, id=None):
+        super().__init__(category_id, state, text, url, id)
 
         self.description = description
         self.created_at = datetime.datetime.utcnow()
@@ -421,8 +423,8 @@ class InnovativePolicyIdea(Link):
         'polymorphic_identity': 'innovative_policy'
     }
 
-    def __init__(self, category_id, state, text=None, url=None, description=None):
-        super().__init__(category_id, state, text, url)
+    def __init__(self, category_id, state, text=None, url=None, description=None, id=None):
+        super().__init__(category_id, state, text, url, id)
         self.description = description
         self.created_at = datetime.datetime.utcnow()
 

--- a/providers.py
+++ b/providers.py
@@ -18,3 +18,15 @@ def post_google(data):
     )
     json_response = json.loads(response.text)
     return json_response
+
+
+def get_categories_from_cms():
+    response = requests.get('http://freefrom-cms.nitro/categories.json?cache=false')
+    json_response = json.loads(response.text)
+    return json_response['data']
+
+
+def get_states_from_cms():
+    response = requests.get('http://freefrom-cms.nitro/states.json?cache=false')
+    json_response = json.loads(response.text)
+    return json_response['data']

--- a/providers.py
+++ b/providers.py
@@ -21,12 +21,18 @@ def post_google(data):
 
 
 def get_categories_from_cms():
-    response = requests.get('http://freefrom-cms.nitro/categories.json?cache=false')
+    if 'CMS_URL' not in os.environ:
+        return []
+
+    response = requests.get(f'{os.environ["CMS_URL"]}/categories.json?cache=false')
     json_response = json.loads(response.text)
     return json_response['data']
 
 
 def get_states_from_cms():
-    response = requests.get('http://freefrom-cms.nitro/states.json?cache=false')
+    if 'CMS_URL' not in os.environ:
+        return []
+
+    response = requests.get(f'{os.environ["CMS_URL"]}/states.json?cache=false')
     json_response = json.loads(response.text)
     return json_response['data']

--- a/services.py
+++ b/services.py
@@ -1,6 +1,9 @@
 from models import (
     Category,
     Criterion,
+    StateGrade,
+    StateCategoryGrade,
+    Score,
     HonorableMention,
     InnovativePolicyIdea,
     ResourceLink
@@ -9,7 +12,7 @@ from providers import post_google
 import strings
 
 
-def update_or_create_category(data, category=Category()):
+def update_or_create_category(data, category=None):
     '''
     Takes a dict of data where the keys are fields of the category model.
     Valid keys are title, help_text, and active. The
@@ -17,6 +20,13 @@ def update_or_create_category(data, category=Category()):
 
     Once created, a category's category cannot be changed.
     '''
+
+    if category is None:
+        if 'id' in data:
+            category = Category(id=data.get('id'))
+        else:
+            category = Category()
+
     if 'title' in data:
         category.title = data['title']
     if 'help_text' in data:
@@ -60,7 +70,11 @@ def update_or_create_link(data, link=None):
     if link is None:
         if subclass is None:
             raise ValueError(strings.require_link_type)
-        link = subclass(category_id=category_id, state=state)
+
+        if 'id' in data:
+            link = subclass(category_id=category_id, state=state, id=data.get('id'))
+        else:
+            link = subclass(category_id=category_id, state=state)
     elif category_id is not None and category_id != link.category_id:
         raise ValueError(strings.cannot_change_category)
     elif state is not None and state != link.state:
@@ -72,6 +86,8 @@ def update_or_create_link(data, link=None):
         link.text = data['text']
     if 'url' in data.keys():
         link.url = data['url']
+    if 'description' in data.keys():
+        link.description = data['description']
 
     # You cannot reactivate a link after deactivating it
     if 'active' in data.keys() and not data['active']:
@@ -89,8 +105,13 @@ def update_or_create_criterion(data, criterion=None):
     Once created, a criterion's category cannot be changed.
     '''
     category_id = data.get('category_id')
+
     if criterion is None:
-        criterion = Criterion(category_id=category_id)
+        if 'id' in data:
+            criterion = Criterion(id=data.get('id'), category_id=category_id)
+        else:
+            criterion = Criterion(category_id=category_id)
+
     elif category_id is not None and category_id != criterion.category_id:
         raise ValueError(strings.cannot_change_category)
 
@@ -108,6 +129,84 @@ def update_or_create_criterion(data, criterion=None):
         criterion.deactivate()
 
     return criterion.save()
+
+
+def update_or_create_score(criterion_id, state_code, meets_criterion):
+    '''
+    Takes a criterion id, a state code, and whether the state meets that criterion.
+    If the current score for this state/criterion does not match what is provided,
+    or no score exists, a new score is created with this information.
+    '''
+    score = Score.query.filter_by(criterion_id=criterion_id, state=state_code) \
+        .order_by(Score.created_at.desc()).first()
+
+    if score is None or score.meets_criterion != meets_criterion:
+        score = Score(
+            criterion_id=criterion_id,
+            state=state_code,
+            meets_criterion=meets_criterion,
+        ).save()
+
+    return score
+
+
+def update_or_create_state_category_grade(category_id, state_code, grade):
+    '''
+    Takes a category id, a state code, and the grade for that state and category.
+    If the current grade for this state/category does not match what is provided, or if no grade
+    exists, a new grade is created with this information.
+    '''
+    state_category_grade = StateCategoryGrade.query.filter_by(
+        state_code=state_code,
+        category_id=category_id,
+    ).order_by(StateCategoryGrade.created_at.desc()).first()
+
+    if state_category_grade is None or state_category_grade.grade != grade:
+        state_category_grade = StateCategoryGrade(
+            state_code=state_code,
+            category_id=category_id,
+            grade=grade,
+        ).save()
+
+    return state_category_grade
+
+
+def update_state(data, state):
+    '''
+    Updates information about the provided state, including the total, quote, overall grade,
+    scores, category grades, and links. It is not possible to create a new state.
+    '''
+    if 'total' in data:
+        state.total = data['total']
+    if 'quote' in data:
+        state.quote = data['quote']
+    if 'grade' in data and int(data['grade']) != state.grades[0].grade:
+        StateGrade(
+            state_code=state.code,
+            grade=int(data['grade'])
+        ).save()
+    if 'criteria_met' in data:
+        for criterion_met in data['criteria_met']:
+            update_or_create_score(
+                criterion_met['id'],
+                state.code,
+                criterion_met['meets_criterion'],
+            )
+    if 'category_grades' in data:
+        for category_grade_data in data['category_grades']:
+            update_or_create_state_category_grade(
+                category_grade_data['id'],
+                state.code,
+                int(category_grade_data['grade']),
+            )
+    for link_type in ['resource_link', 'honorable_mention', 'innovative_policy_idea']:
+        for link_data in data[f'{link_type}s']:
+            link = get_subclass_from_link_type(link_type).query.get(link_data['id'])
+            link_data['type'] = link_type
+
+            update_or_create_link(link_data, link)
+
+    return state.save()
 
 
 forms = [

--- a/services.py
+++ b/services.py
@@ -75,8 +75,6 @@ def update_or_create_link(data, link=None):
             link = subclass(category_id=category_id, state=state, id=data.get('id'))
         else:
             link = subclass(category_id=category_id, state=state)
-    elif category_id is not None and category_id != link.category_id:
-        raise ValueError(strings.cannot_change_category)
     elif state is not None and state != link.state:
         raise ValueError(strings.cannot_change_state)
     elif link_type is not None and not isinstance(link, subclass):
@@ -88,6 +86,8 @@ def update_or_create_link(data, link=None):
         link.url = data['url']
     if 'description' in data.keys():
         link.description = data['description']
+    if 'category_id' in data.keys():
+        link.category_id = category_id
 
     # You cannot reactivate a link after deactivating it
     if 'active' in data.keys() and not data['active']:

--- a/tests/api/test_links.py
+++ b/tests/api/test_links.py
@@ -251,20 +251,6 @@ class ResourceLinksTestCase(unittest.TestCase):
         })
 
     @patch('auth.is_token_valid', return_value=True)
-    def test_put_link_cannot_change_category(self, mock_auth):
-        link = ResourceLink(state=self.state1_code, category_id=self.category.id).save()
-
-        data = {
-            'category_id': 1,
-        }
-
-        response = self.client.put('/links/%i' % link.id, json=data, headers=auth_headers())
-        self.assertEqual(response.status_code, 400)
-
-        json_response = json.loads(response.data)
-        self.assertEqual(json_response['description'], strings.cannot_change_category)
-
-    @patch('auth.is_token_valid', return_value=True)
     def test_put_link_cannot_change_state(self, mock_auth):
         link = ResourceLink(state=self.state1_code, category_id=self.category.id).save()
 

--- a/tests/data/test_importer.py
+++ b/tests/data/test_importer.py
@@ -1,0 +1,100 @@
+import unittest
+
+from app import db
+from models import Category, Criterion
+from data.importer import import_categories
+from tests.test_utils import clear_database
+
+
+class ImporterTestCase(unittest.TestCase):
+    def tearDown(self):
+        clear_database(db)
+
+    def test_import_new_category(self):
+        json = [{
+            'title': 'Economic Abuse Defined in State Laws',
+            'help_text': 'We cannot begin to address economic abuse...',
+            'id': 140,
+            'criteria': [],
+        }]
+
+        result = import_categories(json)
+
+        self.assertEqual(len(result), 1)
+
+        category = result[0]
+
+        self.assertEqual(category['id'], 140)
+        self.assertEqual(category['title'], 'Economic Abuse Defined in State Laws')
+        self.assertEqual(category['help_text'], 'We cannot begin to address economic abuse...')
+        self.assertTrue(category['active'])
+
+        self.assertEqual(len(Category.query.all()), 1)
+
+    def test_update_existing_category(self):
+        category = Category(
+            title='Economic Abuse Defined in State Laws',
+            help_text='We cannot begin to address economic abuse...',
+        ).save()
+
+        json = [{
+            'title': 'New Title',
+            'help_text': 'New Help Text',
+            'id': category.id,
+            'active': False,
+            'criteria': [],
+        }]
+
+        result = import_categories(json)
+
+        self.assertEqual(len(result), 1)
+
+        category = result[0]
+
+        self.assertEqual(category['title'], 'New Title')
+        self.assertEqual(category['help_text'], 'New Help Text')
+        self.assertFalse(category['active'])
+
+        self.assertEqual(len(Category.query.all()), 1)
+
+    def test_new_and_existing_category(self):
+        category = Category(
+            title='Economic Abuse Defined in State Laws',
+            help_text='We cannot begin to address economic abuse...',
+        ).save()
+
+        json = [
+            {
+                'title': 'New Title',
+                'help_text': 'New Help Text',
+                'id': category.id,
+                'active': False,
+                'criteria': [],
+            },
+            {
+                'title': 'Economic Abuse Defined in State Laws',
+                'help_text': 'We cannot begin to address economic abuse...',
+                'id': 140,
+                'criteria': [],
+            },
+        ]
+
+        result = import_categories(json)
+
+        self.assertEqual(len(result), 2)
+
+        category_1 = result[0]
+
+        self.assertEqual(category_1['id'], category.id)
+        self.assertEqual(category_1['title'], 'New Title')
+        self.assertEqual(category_1['help_text'], 'New Help Text')
+        self.assertFalse(category_1['active'])
+
+        category_2 = result[1]
+
+        self.assertEqual(category_2['id'], 140)
+        self.assertEqual(category_2['title'], 'Economic Abuse Defined in State Laws')
+        self.assertEqual(category_2['help_text'], 'We cannot begin to address economic abuse...')
+        self.assertTrue(category_2['active'])
+
+        self.assertEqual(len(Category.query.all()), 2)

--- a/tests/data/test_importer.py
+++ b/tests/data/test_importer.py
@@ -1,8 +1,18 @@
 import unittest
 
 from app import db
-from models import Category, Criterion
-from data.importer import import_categories
+from models import (
+    Category,
+    Criterion,
+    State,
+    StateGrade,
+    StateCategoryGrade,
+    Score,
+    ResourceLink,
+    HonorableMention,
+    InnovativePolicyIdea
+)
+from data.importer import import_categories, import_states
 from tests.test_utils import clear_database
 
 
@@ -10,57 +20,16 @@ class ImporterTestCase(unittest.TestCase):
     def tearDown(self):
         clear_database(db)
 
-    def test_import_new_category(self):
-        json = [{
-            'title': 'Economic Abuse Defined in State Laws',
-            'help_text': 'We cannot begin to address economic abuse...',
-            'id': 140,
-            'criteria': [],
-        }]
-
-        result = import_categories(json)
-
-        self.assertEqual(len(result), 1)
-
-        category = result[0]
-
-        self.assertEqual(category['id'], 140)
-        self.assertEqual(category['title'], 'Economic Abuse Defined in State Laws')
-        self.assertEqual(category['help_text'], 'We cannot begin to address economic abuse...')
-        self.assertTrue(category['active'])
-
-        self.assertEqual(len(Category.query.all()), 1)
-
-    def test_update_existing_category(self):
+    def test_import_category(self):
         category = Category(
             title='Economic Abuse Defined in State Laws',
             help_text='We cannot begin to address economic abuse...',
         ).save()
 
-        json = [{
-            'title': 'New Title',
-            'help_text': 'New Help Text',
-            'id': category.id,
-            'active': False,
-            'criteria': [],
-        }]
-
-        result = import_categories(json)
-
-        self.assertEqual(len(result), 1)
-
-        category = result[0]
-
-        self.assertEqual(category['title'], 'New Title')
-        self.assertEqual(category['help_text'], 'New Help Text')
-        self.assertFalse(category['active'])
-
-        self.assertEqual(len(Category.query.all()), 1)
-
-    def test_new_and_existing_category(self):
-        category = Category(
-            title='Economic Abuse Defined in State Laws',
-            help_text='We cannot begin to address economic abuse...',
+        criterion = Criterion(
+            category_id=category.id,
+            title='The state’s definition of intimate partner violence includes all or similar'
+                  'language to the following...',
         ).save()
 
         json = [
@@ -69,13 +38,30 @@ class ImporterTestCase(unittest.TestCase):
                 'help_text': 'New Help Text',
                 'id': category.id,
                 'active': False,
-                'criteria': [],
+                'criteria': [
+                    {
+                        'id': criterion.id,
+                        'title': 'Edited Criterion',
+                        'adverse': True,
+                        'active': False,
+                    }
+                ],
             },
             {
-                'title': 'Economic Abuse Defined in State Laws',
-                'help_text': 'We cannot begin to address economic abuse...',
+                'title': 'Paid and Protective Leave',
+                'help_text': 'Survivors in the U.S. lose an estimated 8 million days of paid '
+                             'work each year...',
                 'id': 140,
-                'criteria': [],
+                'active': True,
+                'criteria': [
+                    {
+                        'id': 50,
+                        'title': 'Survivors are given leave from work to deal with the '
+                                 'consequences of abuse',
+                        'adverse': False,
+                        'active': True,
+                    }
+                ],
             },
         ]
 
@@ -83,18 +69,225 @@ class ImporterTestCase(unittest.TestCase):
 
         self.assertEqual(len(result), 2)
 
-        category_1 = result[0]
+        category_1 = Category.query.get(category.id)
 
-        self.assertEqual(category_1['id'], category.id)
-        self.assertEqual(category_1['title'], 'New Title')
-        self.assertEqual(category_1['help_text'], 'New Help Text')
-        self.assertFalse(category_1['active'])
+        self.assertEqual(category_1.title, 'New Title')
+        self.assertEqual(category_1.help_text, 'New Help Text')
+        self.assertFalse(category_1.active)
 
-        category_2 = result[1]
+        criterion_1 = Criterion.query.get(criterion.id)
 
-        self.assertEqual(category_2['id'], 140)
-        self.assertEqual(category_2['title'], 'Economic Abuse Defined in State Laws')
-        self.assertEqual(category_2['help_text'], 'We cannot begin to address economic abuse...')
-        self.assertTrue(category_2['active'])
+        self.assertEqual(criterion_1.title, 'Edited Criterion')
+        self.assertEqual(criterion_1.category_id, category_1.id)
+        self.assertTrue(criterion_1.adverse)
+        self.assertFalse(criterion_1.active)
+
+        category_2 = Category.query.get(140)
+
+        self.assertEqual(category_2.title, 'Paid and Protective Leave')
+        self.assertEqual(
+            category_2.help_text,
+            'Survivors in the U.S. lose an estimated 8 million days of paid work each year...'
+        )
+        self.assertTrue(category_2.active)
+
+        criterion_2 = Criterion.query.get(50)
+
+        self.assertEqual(
+            criterion_2.title,
+            'Survivors are given leave from work to deal with the consequences of abuse'
+        )
+        self.assertEqual(criterion_2.category_id, category_2.id)
+        self.assertFalse(criterion_2.adverse)
+        self.assertTrue(criterion_2.active)
 
         self.assertEqual(len(Category.query.all()), 2)
+        self.assertEqual(len(Criterion.query.all()), 2)
+
+    def test_import_state(self):
+        state = State(code='NY', name='New York').save()
+
+        StateGrade(
+            state_code='NY',
+            grade=3,
+        ).save()
+
+        category_1 = Category(
+            title='Economic Abuse Defined in State Laws',
+            help_text='We cannot begin to address economic abuse...',
+        ).save()
+
+        category_2 = Category(
+            title='Paid and Protective Leave',
+            help_text='Survivors in the U.S. lose an estimated...',
+        ).save()
+
+        criterion_1 = Criterion(
+            category_id=category_1.id,
+            title='The state’s definition of intimate partner violence includes all or similar'
+                  'language to the following...',
+        ).save()
+
+        criterion_2 = Criterion(
+            category_id=category_2.id,
+            title='A definition that explicitly excludes economic abuse or tactics',
+            adverse=True
+        ).save()
+
+        StateCategoryGrade(
+            state_code='NY',
+            category_id=category_1.id,
+            grade=2,
+        ).save()
+
+        Score(
+            criterion_id=criterion_1.id,
+            state='NY',
+            meets_criterion='maybe'
+        ).save()
+
+        resource_link = ResourceLink(
+            category_id=category_1.id,
+            state='NY',
+        ).save()
+
+        json = [
+            {
+                'name': 'New York',
+                'code': 'NY',
+                'total': 18,
+                'quote': 'I am unemployed now for 5 months...',
+                'grade': '0',
+                'criteria_met': [
+                    {
+                        'id': criterion_1.id,
+                        'meets_criterion': 'yes'
+                    },
+                    {
+                        'id': criterion_2.id,
+                        'meets_criterion': 'maybe'
+                    },
+                ],
+                'category_grades': [
+                    {
+                        'id': category_1.id,
+                        'grade': 3
+                    },
+                    {
+                        'id': category_2.id,
+                        'grade': 0
+                    }
+                ],
+                'resource_links': [
+                    {
+                        'id': resource_link.id,
+                        'state': 'NY',
+                        'category_id': category_2.id,
+                        'text': 'NY S.O.S. §459-a',
+                        'url': 'https://www.nysenate.gov/legislation/laws/SOS/459-A',
+                        'active': False
+                    },
+                    {
+                        'id': 500,
+                        'state': 'NY',
+                        'category_id': category_1.id,
+                        'text': 'NY E.X.C. §296(c)(1), (2)(i--v), (5)(i-iv)',
+                        'url': 'https://www.nysenate.gov/legislation/laws/EXC/296',
+                        'active': True
+                    }
+                ],
+                'honorable_mentions': [
+                    {
+                        'id': 501,
+                        'state': 'NY',
+                        'category_id': category_1.id,
+                        'text': 'NY SNAP website',
+                        'url': 'https://www.ny.gov/services/apply-snap',
+                        'description': 'In New York, expedited enrollment...',
+                        'active': True
+                    },
+                ],
+                'innovative_policy_ideas': [
+                    {
+                        'id': 502,
+                        'state': 'NY',
+                        'category_id': category_2.id,
+                        'text': 'An innovative policy',
+                        'url': 'https://www.ny.gov/innovative-policy',
+                        'description': 'A new innovative policy for NY...',
+                        'active': True
+                    },
+                ],
+            }
+        ]
+
+        import_states(json)
+
+        state = State.query.get('NY')
+        self.assertEqual(state.total, 18)
+        self.assertEqual(state.quote, 'I am unemployed now for 5 months...')
+
+        state_grades = StateGrade.query.filter_by(state_code='NY').all()
+        self.assertEqual(len(state_grades), 2)
+        self.assertEqual(state_grades[1].grade, 0)
+
+        scores = Score.query.filter_by(state='NY').all()
+        self.assertEqual(len(scores), 3)
+
+        score_1 = Score.query.filter_by(state='NY', criterion_id=criterion_1.id) \
+            .order_by(Score.created_at.desc()).first()
+        self.assertEqual(score_1.meets_criterion, 'yes')
+
+        score_2 = Score.query.filter_by(state='NY', criterion_id=criterion_2.id) \
+            .order_by(Score.created_at.desc()).first()
+        self.assertEqual(score_2.meets_criterion, 'maybe')
+
+        category_grades = StateCategoryGrade.query.filter_by(state_code='NY').all()
+        self.assertEqual(len(category_grades), 3)
+
+        category_grade_1 = StateCategoryGrade.query \
+            .filter_by(state_code='NY', category_id=category_1.id) \
+            .order_by(StateCategoryGrade.created_at.desc()).first()
+        self.assertEqual(category_grade_1.grade, 3)
+
+        category_grade_2 = StateCategoryGrade.query \
+            .filter_by(state_code='NY', category_id=category_2.id) \
+            .order_by(StateCategoryGrade.created_at.desc()).first()
+        self.assertEqual(category_grade_2.grade, 0)
+
+        resource_links = ResourceLink.query.filter_by(state='NY').all()
+        self.assertEqual(len(resource_links), 2)
+        self.assertEqual(resource_links[0].text, 'NY S.O.S. §459-a')
+        self.assertEqual(
+            resource_links[0].url,
+            'https://www.nysenate.gov/legislation/laws/SOS/459-A'
+        )
+        self.assertFalse(resource_links[0].active)
+        self.assertEqual(resource_links[1].text, 'NY E.X.C. §296(c)(1), (2)(i--v), (5)(i-iv)')
+        self.assertEqual(
+            resource_links[1].url,
+            'https://www.nysenate.gov/legislation/laws/EXC/296'
+        )
+        self.assertTrue(resource_links[1].active)
+
+        honorable_mentions = HonorableMention.query.filter_by(state='NY').all()
+        self.assertEqual(len(honorable_mentions), 1)
+        self.assertEqual(honorable_mentions[0].id, 501)
+        self.assertEqual(honorable_mentions[0].text, 'NY SNAP website')
+        self.assertEqual(honorable_mentions[0].url, 'https://www.ny.gov/services/apply-snap')
+        self.assertEqual(
+            honorable_mentions[0].description,
+            'In New York, expedited enrollment...'
+        )
+        self.assertTrue(honorable_mentions[0].active)
+
+        innovative_policy_ideas = InnovativePolicyIdea.query.filter_by(state='NY').all()
+        self.assertEqual(len(innovative_policy_ideas), 1)
+        self.assertEqual(innovative_policy_ideas[0].id, 502)
+        self.assertEqual(innovative_policy_ideas[0].text, 'An innovative policy')
+        self.assertEqual(innovative_policy_ideas[0].url, 'https://www.ny.gov/innovative-policy')
+        self.assertEqual(
+            innovative_policy_ideas[0].description,
+            'A new innovative policy for NY...'
+        )
+        self.assertTrue(innovative_policy_ideas[0].active)


### PR DESCRIPTION
We are currently working on getting a CMS up and running so the FreeFrom staff can update the map data whenever they want! This PR implements the necessary backend work to get that running.

Here's how it works:
- For the CMS, we're using [Craft CMS](https://craftcms.com), which is a customizable CMS framework built on PHP. Using Craft, we can create a CMS that fits the needs of the FreeFrom team with fairly little development work.
- To get the data from Craft CMS into our backend, we do the following:
  - Whenever data is updated in the CMS, have the CMS call a web hook on the map backend
  - The backend then makes an API call to the CMS and pulls all the data in the form of two JSON blobs (one for category data, one for state data)
  - The backend runs a script to update its data locally based on the JSON it pulled from the CMS

I would say this is not an average workflow, but Craft doesn't support implementing custom API calls to fetch and update data, so this is (I think) the best we can do assuming we want to use a CMS framework.

I do think this solution solves two potential concerns for me:
1. Data loss -- because all the data is re-imported every time something is changed, if one of our web hook calls fails, that data will just be updated the next time the FreeFrom staff makes an edit to the site.
2. Load -- I expect updates to be infrequent, and I also expect that the size of the data will remain about the same, so the load on the backend (hopefully) won't become overwhelming.